### PR TITLE
feat: 경쟁 요소 제거 및 성장형 3-star 스테이지 UX 전면 개편

### DIFF
--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/CategoryScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/CategoryScreen.kt
@@ -1,0 +1,132 @@
+package com.mathapp.practice.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun CategoryScreen(
+    appLanguage: AppLanguage,
+    onOperationSelected: (MathOperation) -> Unit,
+    onBack: () -> Unit,
+    progressVersion: Int
+) {
+    val ops = MathOperation.entries
+    val progressList = remember(progressVersion) { ops.map { operationProgress(it) } }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Top bar
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+            }
+            Text(
+                L10n.string("select_operation", appLanguage),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.width(48.dp))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // 2x2 grid of operation cards
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            ops.chunked(2).forEachIndexed { rowIdx, rowOps ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    rowOps.forEachIndexed { colIdx, op ->
+                        val globalIdx = rowIdx * 2 + colIdx
+                        OperationCard(
+                            operation = op,
+                            progress = progressList[globalIdx],
+                            appLanguage = appLanguage,
+                            modifier = Modifier.weight(1f).fillMaxHeight(),
+                            onClick = { onOperationSelected(op) }
+                        )
+                    }
+                    // Fill gap if odd number of ops in last row
+                    if (rowOps.size < 2) Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OperationCard(
+    operation: MathOperation,
+    progress: Float,
+    appLanguage: AppLanguage,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val stagesDone = (progress * 10).toInt()
+
+    Surface(
+        modifier = modifier,
+        onClick = onClick,
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 2.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            // Operation symbol (big)
+            Text(
+                text = operation.symbol,
+                fontSize = 56.sp,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            // Operation name
+            Text(
+                text = opName(operation, appLanguage),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            // Progress bar
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(6.dp),
+                trackColor = MaterialTheme.colorScheme.background
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                    text = "$stagesDone / 10",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/GameScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/GameScreen.kt
@@ -1,6 +1,5 @@
 package com.mathapp.practice.ui
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.*
@@ -16,9 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.text.input.ImeAction
@@ -29,47 +27,20 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.yield
-import kotlin.random.Random
-
-enum class GameLevel { EASY, NORMAL }
-
-data class MathProblem(val num1: Int, val num2: Int, val op: String) {
-    val answer: Int = if (op == "+") num1 + num2 else num1 - num2
-    val displayText: String = "$num1 $op $num2"
-}
 
 @Composable
 fun GameScreen(
-    level: GameLevel,
-    bestTime: Float,
+    operation: MathOperation,
+    stageNumber: Int,
     appLanguage: AppLanguage,
-    onComplete: (Float) -> Unit,
+    onComplete: (stars: Int, correctCount: Int, avgSeconds: Float) -> Unit,
     onBack: () -> Unit
 ) {
-    val problems = remember(level) {
-        List(10) {
-            when (level) {
-                GameLevel.EASY -> {
-                    val num1 = Random.nextInt(0, 100)
-                    val num2 = Random.nextInt(0, 11)
-                    val op = if (Random.nextBoolean()) "+" else "-"
-                    if (op == "-" && num2 > num1) {
-                        MathProblem(num1 = num2, num2 = num1, op = op)
-                    } else {
-                        MathProblem(num1 = num1, num2 = num2, op = op)
-                    }
-                }
-                GameLevel.NORMAL -> MathProblem(
-                    num1 = Random.nextInt(0, 100),
-                    num2 = Random.nextInt(0, 100),
-                    op = if (Random.nextBoolean()) "+" else "-"
-                )
-            }
-        }
-    }
+    val problems = remember(operation, stageNumber) { generateProblems(operation, stageNumber) }
 
     var currentIndex by remember { mutableIntStateOf(0) }
     var userAnswer by remember { mutableStateOf("") }
+    // Hidden timer: track elapsed wall-clock time from game start
     var elapsedTime by remember { mutableFloatStateOf(0f) }
     var showResult by remember { mutableStateOf<Boolean?>(null) }
     var showQuitDialog by remember { mutableStateOf(false) }
@@ -78,15 +49,19 @@ fun GameScreen(
     var lastInputMutationAt by remember { mutableLongStateOf(0L) }
     val effectiveStart = remember { mutableLongStateOf(currentTimeMillis()) }
 
+    // Track first-attempt correctness for each problem (for star calculation)
+    val firstAttemptDone = remember { BooleanArray(10) { false } }
+    val correctOnFirstAttempt = remember { BooleanArray(10) { false } }
+
+    // Countdown before game starts
+    var showCountdown by remember { mutableStateOf(true) }
+
     val focusRequester = remember { FocusRequester() }
 
-    LaunchedEffect(Unit) {
-        // Focus is sometimes not immediately granted on iOS; retry a few times.
-        repeat(6) {
-            yield()
-            focusRequester.requestFocus()
-            delay(80)
-        }
+    // Timer loop (runs after countdown, hidden from UI)
+    LaunchedEffect(showCountdown) {
+        if (showCountdown) return@LaunchedEffect
+        repeat(6) { yield(); focusRequester.requestFocus(); delay(80) }
         while (currentIndex < 10) {
             delay(10)
             if (!isPaused) {
@@ -102,65 +77,71 @@ fun GameScreen(
     }
 
     LaunchedEffect(showResult) {
-        if (showResult == null && currentIndex < 10) {
+        if (showResult == null && currentIndex < 10 && !showCountdown) {
             focusRequester.requestFocus()
         }
     }
 
     val onSubmit = {
-        val currentProblem = if (currentIndex < problems.size) problems[currentIndex] else null
+        val prob = if (currentIndex < problems.size) problems[currentIndex] else null
         val ans = userAnswer.toIntOrNull()
-        if (userAnswer.isNotEmpty() && userAnswer != "-" && ans != null && currentProblem != null) {
-            showResult = (ans == currentProblem.answer)
+        if (userAnswer.isNotEmpty() && userAnswer != "-" && ans != null && prob != null) {
+            val isCorrect = ans == prob.answer
+            if (!firstAttemptDone[currentIndex]) {
+                firstAttemptDone[currentIndex] = true
+                if (isCorrect) correctOnFirstAttempt[currentIndex] = true
+            }
+            showResult = isCorrect
             lastInputMutationAt = currentTimeMillis()
         }
     }
 
     val currentProblem = if (currentIndex < problems.size) problems[currentIndex] else null
+    val showMinus = operation == MathOperation.SUBTRACTION
 
     DisposableEffect(Unit) {
         setHardwareKeyboardHandler(
             onDigit = { digit ->
                 val now = currentTimeMillis()
-                if (currentIndex < 10 && showResult == null && !showQuitDialog && now - lastInputMutationAt > 35) {
+                if (currentIndex < 10 && showResult == null && !showQuitDialog && !showCountdown && now - lastInputMutationAt > 35) {
                     appendDigit(digit, userAnswer) { userAnswer = it }
                     lastInputMutationAt = now
                 }
             },
             onBackspace = {
                 val now = currentTimeMillis()
-                if (currentIndex < 10 && showResult == null && !showQuitDialog && now - lastInputMutationAt > 35) {
+                if (currentIndex < 10 && showResult == null && !showQuitDialog && !showCountdown && now - lastInputMutationAt > 35) {
                     if (userAnswer.isNotEmpty()) userAnswer = userAnswer.dropLast(1)
                     lastInputMutationAt = now
                 }
             },
             onSubmit = {
                 val now = currentTimeMillis()
-                if (currentIndex < 10 && showResult == null && !showQuitDialog && now - lastInputMutationAt > 35) {
+                if (currentIndex < 10 && showResult == null && !showQuitDialog && !showCountdown && now - lastInputMutationAt > 35) {
                     onSubmit()
                     lastInputMutationAt = now
                 }
             },
             onMinus = {
                 val now = currentTimeMillis()
-                if (currentIndex < 10 && showResult == null && !showQuitDialog && now - lastInputMutationAt > 35) {
+                if (showMinus && currentIndex < 10 && showResult == null && !showQuitDialog && !showCountdown && now - lastInputMutationAt > 35) {
                     if (userAnswer.isEmpty()) userAnswer = "-"
                     lastInputMutationAt = now
                 }
             }
         )
-        onDispose {
-            setHardwareKeyboardHandler()
-        }
+        onDispose { setHardwareKeyboardHandler() }
     }
 
-    BoxWithConstraints(
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        // Countdown overlay
+        if (showCountdown) {
+            CountdownOverlay(appLanguage = appLanguage, onComplete = { showCountdown = false })
+            return@BoxWithConstraints
+        }
+
+        // Hidden iOS text input bridge
         if (requiresHiddenTextInputBridge()) {
-            // iOS hardware keyboard input is much more reliable through the platform
-            // text input system than through raw key events. Keep this hidden field focused.
             BasicTextField(
                 value = userAnswer,
                 onValueChange = { raw ->
@@ -170,17 +151,9 @@ fun GameScreen(
                     if (submitRequested) onSubmit()
                 },
                 singleLine = true,
-                keyboardOptions = KeyboardOptions(
-                    // Use Ascii so hardware keyboard input is not filtered at the platform layer;
-                    // we sanitize manually.
-                    keyboardType = KeyboardType.Ascii,
-                    imeAction = ImeAction.Done
-                ),
-                keyboardActions = KeyboardActions(
-                    onDone = { onSubmit() }
-                ),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii, imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { onSubmit() }),
                 modifier = Modifier
-                    // Needs a real (non-zero) size and non-zero alpha on iOS to reliably become first responder.
                     .align(Alignment.TopStart)
                     .size(12.dp)
                     .alpha(0.01f)
@@ -188,27 +161,18 @@ fun GameScreen(
                     .onFocusChanged { state -> isInputFocused = state.isFocused }
                     .focusable()
                     .onKeyEvent { keyEvent ->
-                        // Fallback path for platforms where Enter doesn't get reflected into text.
                         if (keyEvent.type == KeyEventType.KeyUp) {
                             when (keyEvent.key) {
-                                Key.Enter, Key.NumPadEnter -> {
-                                    onSubmit()
-                                    true
-                                }
-                                else -> {
-                                    when (keyEvent.utf16CodePoint) {
-                                        10, 13 -> { onSubmit(); true }
-                                        else -> false
-                                    }
+                                Key.Enter, Key.NumPadEnter -> { onSubmit(); true }
+                                else -> when (keyEvent.utf16CodePoint) {
+                                    10, 13 -> { onSubmit(); true }
+                                    else -> false
                                 }
                             }
-                        } else {
-                            false
-                        }
+                        } else false
                     }
             )
         } else {
-            // Android uses Activity-level dispatch for hardware keys; keep only a focus target.
             Box(
                 modifier = Modifier
                     .align(Alignment.TopStart)
@@ -221,66 +185,56 @@ fun GameScreen(
         }
 
         val isLandscape = maxWidth > maxHeight
+
         if (currentProblem != null) {
             Column(modifier = Modifier.fillMaxSize()) {
-                // Top Bar
+                // ── Top bar (no timer shown) ──
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(onClick = { showQuitDialog = true; isPaused = true }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                     }
+                    // Stage label
                     Text(
-                        L10n.string("time_format", appLanguage, elapsedTime),
-                        style = MaterialTheme.typography.titleMedium
+                        "${opName(operation, appLanguage)} ${L10n.string("stage_num_format", appLanguage, stageNumber)}",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    // Problem progress (e.g. "3 / 10")
                     Text(
-                        "${currentIndex + 1}/10",
+                        L10n.string("problem_progress", appLanguage, currentIndex + 1),
                         style = MaterialTheme.typography.titleMedium
                     )
                 }
 
+                // Progress bar (thin, shows problem index visually)
+                LinearProgressIndicator(
+                    progress = { (currentIndex + 1) / 10f },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(4.dp),
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+
                 if (isLandscape) {
                     Row(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                        // Left: Problem
+                        // Left: problem
                         Box(
                             modifier = Modifier.weight(1f).fillMaxHeight(),
                             contentAlignment = Alignment.Center
                         ) {
-                            Surface(
-                                shape = RoundedCornerShape(24.dp),
-                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                            ProblemCard(
+                                problem = currentProblem,
+                                userAnswer = userAnswer,
                                 modifier = Modifier.padding(24.dp)
-                            ) {
-                                Column(
-                                    modifier = Modifier.padding(40.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.spacedBy(24.dp)
-                                ) {
-                                    Text(
-                                        currentProblem.displayText,
-                                        style = MaterialTheme.typography.displayLarge,
-                                        fontSize = 64.sp
-                                    )
-                                    Surface(
-                                        shape = RoundedCornerShape(16.dp),
-                                        color = MaterialTheme.colorScheme.surfaceVariant
-                                    ) {
-                                        Text(
-                                            text = userAnswer.ifEmpty { " " },
-                                            modifier = Modifier.padding(horizontal = 48.dp, vertical = 12.dp),
-                                            style = MaterialTheme.typography.displayMedium,
-                                            fontSize = 48.sp
-                                        )
-                                    }
-                                }
-                            }
+                            )
                         }
-                        // Right: Keypad
+                        // Right: keypad
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth(0.5f)
@@ -291,31 +245,15 @@ fun GameScreen(
                             NumberKeypad(
                                 modifier = Modifier.padding(24.dp),
                                 confirmTitle = L10n.string("confirm", appLanguage),
-                                onDigit = { d ->
-                                    appendDigit(d, userAnswer) { userAnswer = it }
-                                    lastInputMutationAt = currentTimeMillis()
-                                    focusRequester.requestFocus()
-                                },
-                                onBackspace = {
-                                    if (userAnswer.isNotEmpty()) userAnswer = userAnswer.dropLast(1)
-                                    lastInputMutationAt = currentTimeMillis()
-                                    focusRequester.requestFocus()
-                                },
-                                onSubmit = {
-                                    onSubmit()
-                                    lastInputMutationAt = currentTimeMillis()
-                                    focusRequester.requestFocus()
-                                },
-                                onMinus = {
-                                    if (userAnswer.isEmpty()) userAnswer = "-"
-                                    lastInputMutationAt = currentTimeMillis()
-                                    focusRequester.requestFocus()
-                                }
+                                showMinus = showMinus,
+                                onDigit = { d -> appendDigit(d, userAnswer) { userAnswer = it }; lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() },
+                                onBackspace = { if (userAnswer.isNotEmpty()) userAnswer = userAnswer.dropLast(1); lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() },
+                                onSubmit = { onSubmit(); lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() },
+                                onMinus = { if (showMinus && userAnswer.isEmpty()) userAnswer = "-"; lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() }
                             )
                         }
                     }
                 } else {
-                    // Portrait Mode
                     Column(
                         modifier = Modifier.weight(1f).fillMaxWidth().padding(24.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -339,58 +277,47 @@ fun GameScreen(
                         }
                     }
                     NumberKeypad(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
                         confirmTitle = L10n.string("confirm", appLanguage),
-                        onDigit = { d ->
-                            appendDigit(d, userAnswer) { userAnswer = it }
-                            lastInputMutationAt = currentTimeMillis()
-                            focusRequester.requestFocus()
-                        },
-                        onBackspace = {
-                            if (userAnswer.isNotEmpty()) userAnswer = userAnswer.dropLast(1)
-                            lastInputMutationAt = currentTimeMillis()
-                            focusRequester.requestFocus()
-                        },
-                        onSubmit = {
-                            onSubmit()
-                            lastInputMutationAt = currentTimeMillis()
-                            focusRequester.requestFocus()
-                        },
-                        onMinus = {
-                            if (userAnswer.isEmpty()) userAnswer = "-"
-                            lastInputMutationAt = currentTimeMillis()
-                            focusRequester.requestFocus()
-                        }
+                        showMinus = showMinus,
+                        onDigit = { d -> appendDigit(d, userAnswer) { userAnswer = it }; lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() },
+                        onBackspace = { if (userAnswer.isNotEmpty()) userAnswer = userAnswer.dropLast(1); lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() },
+                        onSubmit = { onSubmit(); lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() },
+                        onMinus = { if (showMinus && userAnswer.isEmpty()) userAnswer = "-"; lastInputMutationAt = currentTimeMillis(); focusRequester.requestFocus() }
                     )
                 }
             }
         } else {
-            // Result Screen
-            ResultView(elapsedTime, bestTime, appLanguage, onComplete)
+            // All 10 problems done — calculate and report
+            val correctCount = correctOnFirstAttempt.count { it }
+            val avgSeconds = elapsedTime / 10f
+            val stars = calcStars(correctCount, elapsedTime)
+            LaunchedEffect(Unit) {
+                onComplete(stars, correctCount, avgSeconds)
+            }
         }
 
-        // Feedback & Dialogs
+        // Feedback overlay (correct / wrong)
         showResult?.let { correct ->
             LaunchedEffect(correct) {
-                delay(500)
+                delay(if (correct) 400L else 700L)
                 showResult = null
-                if (correct) {
-                    currentIndex++
-                    userAnswer = ""
-                } else {
-                    userAnswer = ""
-                }
+                userAnswer = ""
+                if (correct) currentIndex++
             }
             Box(
-                modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.3f)),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        if (correct) Color(0x4400CC44)
+                        else Color(0x44FF4444)
+                    ),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = if (correct) "✓" else "✗",
                     fontSize = 120.sp,
-                    color = if (correct) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                    color = if (correct) Color(0xFF00AA00) else Color(0xFFCC0000)
                 )
             }
         }
@@ -405,114 +332,41 @@ fun GameScreen(
     }
 }
 
+// ─── Problem card (landscape mode) ───────────────────────────────────────────
+
 @Composable
-fun ResultView(elapsedTime: Float, bestTime: Float, appLanguage: AppLanguage, onComplete: (Float) -> Unit) {
-    val isNewRecord = bestTime == 0f || elapsedTime <= bestTime
-    Box(modifier = Modifier.fillMaxSize()) {
-        if (isNewRecord) {
-            ConfettiView(modifier = Modifier.fillMaxSize())
-        }
+private fun ProblemCard(problem: MathProblem, userAnswer: String, modifier: Modifier = Modifier) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+        modifier = modifier
+    ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(24.dp),
+            modifier = Modifier.padding(40.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            Spacer(modifier = Modifier.weight(1f))
             Text(
-                L10n.string("complete", appLanguage),
-                style = MaterialTheme.typography.headlineLarge,
-                fontSize = 38.sp
+                problem.displayText,
+                style = MaterialTheme.typography.displayLarge,
+                fontSize = 64.sp
             )
-            Spacer(modifier = Modifier.height(28.dp))
-            if (isNewRecord) {
-                Text(
-                    L10n.string("new_record_title", appLanguage),
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    L10n.string("new_record_message", appLanguage),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 24.dp)
-                )
-            } else {
-                Text(
-                    L10n.string("well_done", appLanguage),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            Text(
-                L10n.string("time_format", appLanguage, elapsedTime),
-                style = MaterialTheme.typography.headlineMedium,
-                fontSize = 32.sp,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(top = 8.dp)
-            )
-            if (!isNewRecord && bestTime > 0) {
-                Text(
-                    L10n.string("best_record_format", appLanguage, L10n.string("time_format", appLanguage, bestTime)),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp)
-                )
-            }
-            Button(
-                onClick = { onComplete(elapsedTime) },
-                modifier = Modifier
-                    .padding(top = 32.dp)
-                    .padding(horizontal = 40.dp, vertical = 14.dp)
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant
             ) {
-                Text(L10n.string("to_main", appLanguage), style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = userAnswer.ifEmpty { " " },
+                    modifier = Modifier.padding(horizontal = 48.dp, vertical = 12.dp),
+                    style = MaterialTheme.typography.displayMedium,
+                    fontSize = 48.sp
+                )
             }
-            Spacer(modifier = Modifier.weight(1f))
         }
     }
 }
 
-@Composable
-fun ConfettiView(modifier: Modifier = Modifier) {
-    val startTime = remember { currentTimeMillis() }
-    var elapsed by remember { mutableFloatStateOf(0f) }
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(16)
-            elapsed = (currentTimeMillis() - startTime) / 1000f
-        }
-    }
-    val particleCount = 80
-    val particles = remember {
-        List(particleCount) { i ->
-            ConfettiParticle(
-                startX = Random.nextFloat(),
-                startY = 1f + Random.nextFloat() * 0.2f,
-                size = (8 + Random.nextInt(11)).toFloat(),
-                color = listOf(
-                    Color(0xFF, 0x69, 0xB4), Color(0xFF, 0x8C, 0x00), Color(0xFF, 0xFF, 0x00), Color(0x00, 0xFF, 0x00),
-                    Color(0x98, 0xFB, 0x98), Color(0x00, 0xFF, 0xFF), Color(0x00, 0x00, 0xFF), Color(0x8A, 0x2B, 0xE2), Color(0xFF, 0x00, 0x00)
-                ).random(),
-                startDelay = i * 0.05f,
-                speed = 100f + Random.nextFloat() * 120f,
-                drift = -120f + Random.nextFloat() * 240f
-            )
-        }
-    }
-    Canvas(modifier = modifier) {
-        val w = size.width
-        val h = size.height
-        particles.forEach { p ->
-            val t = maxOf(0f, elapsed - p.startDelay)
-            val y = (p.startY * h) - (p.speed * t)
-            val x = (p.startX * w) + (p.drift * t * 0.25f) + (kotlin.math.sin(t.toDouble() * 2.5).toFloat() * 25f)
-            if (y > -50) {
-                drawCircle(color = p.color.copy(alpha = 0.85f), radius = p.size, center = Offset(x, y))
-            }
-        }
-    }
-}
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 private fun appendDigit(digit: String, current: String, update: (String) -> Unit) {
     val maxLen = if (current.startsWith("-")) 5 else 4
@@ -520,13 +374,12 @@ private fun appendDigit(digit: String, current: String, update: (String) -> Unit
 }
 
 private fun sanitizeAnswerInput(raw: String): String {
-    // Keep digits and an optional leading '-' only.
     val stripped = raw.filterNot { it == '\n' || it == '\r' }
     val cleaned = buildString {
         for (c in stripped) {
             when {
-                c.isDigit() -> append(c)
-                c == '-' && isEmpty() -> append(c)
+                c.isDigit()              -> append(c)
+                c == '-' && isEmpty()    -> append(c)
             }
         }
     }
@@ -534,25 +387,29 @@ private fun sanitizeAnswerInput(raw: String): String {
     return cleaned.take(maxLen)
 }
 
-private data class ConfettiParticle(
-    val startX: Float,
-    val startY: Float,
-    val size: Float,
-    val color: Color,
-    val startDelay: Float,
-    val speed: Float,
-    val drift: Float
-)
+// ─── Quit dialog ──────────────────────────────────────────────────────────────
 
 @Composable
 fun QuitConfirmDialog(appLanguage: AppLanguage, onDismiss: () -> Unit, onConfirm: () -> Unit) {
     Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
         Surface(shape = RoundedCornerShape(28.dp), modifier = Modifier.fillMaxWidth(0.85f).padding(24.dp)) {
             Column(modifier = Modifier.padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(L10n.string("quit_confirm", appLanguage), style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(bottom = 24.dp))
+                Text(
+                    L10n.string("quit_confirm", appLanguage),
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(bottom = 24.dp)
+                )
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                    OutlinedButton(onClick = onDismiss, modifier = Modifier.weight(1f)) { Text(L10n.string("no", appLanguage)) }
-                    Button(onClick = onConfirm, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error), modifier = Modifier.weight(1f)) { Text(L10n.string("yes", appLanguage)) }
+                    OutlinedButton(onClick = onDismiss, modifier = Modifier.weight(1f)) {
+                        Text(L10n.string("no", appLanguage))
+                    }
+                    Button(
+                        onClick = onConfirm,
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text(L10n.string("yes", appLanguage))
+                    }
                 }
             }
         }

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/Localization.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/Localization.kt
@@ -41,7 +41,31 @@ object L10n {
             "level_normal" to "보통",
             "help_title" to "레벨 설명",
             "help_easy_desc" to "• 왼쪽 숫자: 0~99\n• 오른쪽 숫자: 0~10\n• 뺄셈 시 결과가 음수가 되지 않음",
-            "help_normal_desc" to "• 왼쪽 숫자: 0~99\n• 오른쪽 숫자: 0~99\n• 덧셈과 뺄셈 (음수 가능)"
+            "help_normal_desc" to "• 왼쪽 숫자: 0~99\n• 오른쪽 숫자: 0~99\n• 덧셈과 뺄셈 (음수 가능)",
+            // ── New strings for stage UX ──
+            "resume" to "이어서 하기",
+            "new_start" to "새로 시작하기",
+            "select_operation" to "연산 선택",
+            "overall_progress" to "전체 진척도",
+            "locked" to "잠김",
+            "stage_map_title" to "스테이지 선택",
+            "reset_progress" to "진척도 초기화",
+            "reset_progress_confirm_title" to "진척도를 초기화하시겠습니까?",
+            "reset_progress_confirm_message" to "모든 스테이지 기록이 삭제됩니다.",
+            "stage_num_format" to "%d단계",
+            "resume_hint" to "%s %d단계",
+            "problem_progress" to "%d / 10",
+            "result_title_3star" to "완벽해요!",
+            "result_title_2star" to "잘했어요!",
+            "result_title_1star" to "완주했어요!",
+            "correct_format" to "맞힌 문제: %d / 10",
+            "avg_time_format" to "평균 %.1f초",
+            "retry" to "다시 하기",
+            "next_stage" to "다음 단계로",
+            "to_stage_map" to "스테이지 맵으로",
+            "star_cond_3" to "⭐⭐⭐  만점 + 평균 3초 이하",
+            "star_cond_2" to "⭐⭐  8문제 이상 정답",
+            "star_cond_1" to "⭐  완주 성공"
         ),
         AppLanguage.ENGLISH to mapOf(
             "reset_records" to "Reset Records",
@@ -70,7 +94,31 @@ object L10n {
             "level_normal" to "Normal",
             "help_title" to "Level Guide",
             "help_easy_desc" to "• Left number: 0~99\n• Right number: 0~10\n• Subtraction: result is never negative",
-            "help_normal_desc" to "• Left number: 0~99\n• Right number: 0~99\n• Addition and subtraction (negative allowed)"
+            "help_normal_desc" to "• Left number: 0~99\n• Right number: 0~99\n• Addition and subtraction (negative allowed)",
+            // ── New strings for stage UX ──
+            "resume" to "Continue",
+            "new_start" to "Choose Operation",
+            "select_operation" to "Select Operation",
+            "overall_progress" to "Overall Progress",
+            "locked" to "Locked",
+            "stage_map_title" to "Select Stage",
+            "reset_progress" to "Reset Progress",
+            "reset_progress_confirm_title" to "Reset all progress?",
+            "reset_progress_confirm_message" to "All stage records will be deleted.",
+            "stage_num_format" to "Stage %d",
+            "resume_hint" to "%s Stage %d",
+            "problem_progress" to "%d / 10",
+            "result_title_3star" to "Perfect!",
+            "result_title_2star" to "Great job!",
+            "result_title_1star" to "You did it!",
+            "correct_format" to "Correct: %d / 10",
+            "avg_time_format" to "Avg %.1fs",
+            "retry" to "Try Again",
+            "next_stage" to "Next Stage",
+            "to_stage_map" to "Stage Map",
+            "star_cond_3" to "⭐⭐⭐  Perfect score + avg ≤ 3s",
+            "star_cond_2" to "⭐⭐  8 or more correct",
+            "star_cond_1" to "⭐  Finish all 10"
         ),
         AppLanguage.CHINESE_TRADITIONAL to mapOf(
             "reset_records" to "重置紀錄",
@@ -99,7 +147,31 @@ object L10n {
             "level_normal" to "普通",
             "help_title" to "難度說明",
             "help_easy_desc" to "• 左側數字：0~99\n• 右側數字：0~10\n• 減法時結果不為負數",
-            "help_normal_desc" to "• 左側數字：0~99\n• 右側數字：0~99\n• 加法和減法（可為負數）"
+            "help_normal_desc" to "• 左側數字：0~99\n• 右側數字：0~99\n• 加法和減法（可為負數）",
+            // ── New strings for stage UX ──
+            "resume" to "繼續",
+            "new_start" to "選擇運算",
+            "select_operation" to "選擇運算",
+            "overall_progress" to "整體進度",
+            "locked" to "已鎖定",
+            "stage_map_title" to "選擇關卡",
+            "reset_progress" to "重置進度",
+            "reset_progress_confirm_title" to "確定要重置進度嗎？",
+            "reset_progress_confirm_message" to "所有關卡記錄將被刪除。",
+            "stage_num_format" to "第%d關",
+            "resume_hint" to "%s 第%d關",
+            "problem_progress" to "%d / 10",
+            "result_title_3star" to "太棒了！",
+            "result_title_2star" to "做得好！",
+            "result_title_1star" to "完成了！",
+            "correct_format" to "答對：%d / 10",
+            "avg_time_format" to "平均 %.1f秒",
+            "retry" to "再試一次",
+            "next_stage" to "下一關",
+            "to_stage_map" to "關卡地圖",
+            "star_cond_3" to "⭐⭐⭐  滿分 + 平均≤3秒",
+            "star_cond_2" to "⭐⭐  答對8題以上",
+            "star_cond_1" to "⭐  完成全部題目"
         ),
         AppLanguage.CHINESE_SIMPLIFIED to mapOf(
             "reset_records" to "重置记录",
@@ -128,7 +200,31 @@ object L10n {
             "level_normal" to "普通",
             "help_title" to "难度说明",
             "help_easy_desc" to "• 左侧数字：0~99\n• 右侧数字：0~10\n• 减法时结果不为负数",
-            "help_normal_desc" to "• 左侧数字：0~99\n• 右侧数字：0~99\n• 加法和减法（可为负数）"
+            "help_normal_desc" to "• 左侧数字：0~99\n• 右侧数字：0~99\n• 加法和减法（可为负数）",
+            // ── New strings for stage UX ──
+            "resume" to "继续",
+            "new_start" to "选择运算",
+            "select_operation" to "选择运算",
+            "overall_progress" to "整体进度",
+            "locked" to "已锁定",
+            "stage_map_title" to "选择关卡",
+            "reset_progress" to "重置进度",
+            "reset_progress_confirm_title" to "确定要重置进度吗？",
+            "reset_progress_confirm_message" to "所有关卡记录将被删除。",
+            "stage_num_format" to "第%d关",
+            "resume_hint" to "%s 第%d关",
+            "problem_progress" to "%d / 10",
+            "result_title_3star" to "太棒了！",
+            "result_title_2star" to "做得好！",
+            "result_title_1star" to "完成了！",
+            "correct_format" to "答对：%d / 10",
+            "avg_time_format" to "平均 %.1f秒",
+            "retry" to "再试一次",
+            "next_stage" to "下一关",
+            "to_stage_map" to "关卡地图",
+            "star_cond_3" to "⭐⭐⭐  满分 + 平均≤3秒",
+            "star_cond_2" to "⭐⭐  答对8题以上",
+            "star_cond_1" to "⭐  完成全部题目"
         ),
         AppLanguage.JAPANESE to mapOf(
             "reset_records" to "記録をリセット",
@@ -157,7 +253,31 @@ object L10n {
             "level_normal" to "ふつう",
             "help_title" to "レベル説明",
             "help_easy_desc" to "• 左の数字：0~99\n• 右の数字：0~10\n• 引き算は結果がマイナスにならない",
-            "help_normal_desc" to "• 左の数字：0~99\n• 右の数字：0~99\n• 足し算と引き算（マイナス可）"
+            "help_normal_desc" to "• 左の数字：0~99\n• 右の数字：0~99\n• 足し算と引き算（マイナス可）",
+            // ── New strings for stage UX ──
+            "resume" to "続ける",
+            "new_start" to "演算を選ぶ",
+            "select_operation" to "演算を選択",
+            "overall_progress" to "全体の進捗",
+            "locked" to "ロック中",
+            "stage_map_title" to "ステージ選択",
+            "reset_progress" to "進捗をリセット",
+            "reset_progress_confirm_title" to "進捗をリセットしますか？",
+            "reset_progress_confirm_message" to "すべてのステージ記録が削除されます。",
+            "stage_num_format" to "第%dステージ",
+            "resume_hint" to "%s 第%dステージ",
+            "problem_progress" to "%d / 10",
+            "result_title_3star" to "完璧！",
+            "result_title_2star" to "よくできました！",
+            "result_title_1star" to "クリア！",
+            "correct_format" to "正解: %d / 10",
+            "avg_time_format" to "平均 %.1f秒",
+            "retry" to "もう一度",
+            "next_stage" to "次のステージへ",
+            "to_stage_map" to "ステージマップ",
+            "star_cond_3" to "⭐⭐⭐  満点 + 平均3秒以内",
+            "star_cond_2" to "⭐⭐  8問以上正解",
+            "star_cond_1" to "⭐  全問クリア"
         )
     )
 
@@ -167,7 +287,7 @@ object L10n {
     }
 }
 
-/** Multiplatform string formatter — supports %.Nf and %s specifiers only. */
+/** Multiplatform string formatter — supports %.Nf, %s, and %d specifiers. */
 private fun kmpFormat(template: String, vararg args: Any): String {
     val result = StringBuilder()
     var argIndex = 0
@@ -177,6 +297,7 @@ private fun kmpFormat(template: String, vararg args: Any): String {
             val rest = template.substring(i + 1)
             val floatMatch = Regex("^\\.(\\d+)f").find(rest)
             val stringMatch = rest.startsWith("s")
+            val intMatch = rest.startsWith("d")
             when {
                 floatMatch != null -> {
                     val decimals = floatMatch.groupValues[1].toInt()
@@ -186,6 +307,10 @@ private fun kmpFormat(template: String, vararg args: Any): String {
                 }
                 stringMatch -> {
                     result.append(args.getOrNull(argIndex++)?.toString() ?: "")
+                    i += 2
+                }
+                intMatch -> {
+                    result.append((args.getOrNull(argIndex++) as? Number)?.toInt() ?: 0)
                     i += 2
                 }
                 else -> {

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MainScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MainScreen.kt
@@ -1,40 +1,14 @@
 package com.mathapp.practice.ui
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.outlined.HelpOutline
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -42,31 +16,26 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-@OptIn(ExperimentalMaterial3Api::class)
+// ─── Home Screen ──────────────────────────────────────────────────────────────
+
 @Composable
-fun MainScreen(
+fun HomeScreen(
+    appLanguage: AppLanguage,
     colorSchemeMode: Int,
     onColorSchemeChange: (Int) -> Unit,
-    appLanguage: AppLanguage,
     appLanguageRaw: String,
     onAppLanguageChange: (String) -> Unit,
-    bestTime: Float,
-    selectedLevel: GameLevel,
-    onSelectedLevelChange: (GameLevel) -> Unit,
-    onStartClick: () -> Unit,
-    showCountdown: Boolean,
-    onShowCountdownChange: (Boolean) -> Unit,
-    onGameActiveChange: (Boolean) -> Unit,
-    onResetRecords: () -> Unit
+    onResumeClick: (Pair<MathOperation, Int>) -> Unit,
+    onNewStartClick: () -> Unit,
+    onResetProgress: () -> Unit,
+    progressVersion: Int
 ) {
+    val lastStage = remember(progressVersion) { getLastPlayedStage() }
     var showResetConfirm by remember { mutableStateOf(false) }
     var showLanguageSheet by remember { mutableStateOf(false) }
-    var showHelp by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
-        if (appLanguageRaw.isEmpty()) {
-            onAppLanguageChange(getDeviceLanguageCode())
-        }
+        if (appLanguageRaw.isEmpty()) onAppLanguageChange(getDeviceLanguageCode())
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -77,35 +46,55 @@ fun MainScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.SpaceBetween
         ) {
+            // ── Top bar ──
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                var showMenu by remember { mutableStateOf(false) }
-                IconButton(onClick = { showHelp = true }) {
-                    Icon(Icons.Outlined.HelpOutline, contentDescription = null)
-                }
+                Spacer(modifier = Modifier.width(48.dp))
+
+                Text(
+                    text = "Math",
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontSize = 40.sp
+                )
+
                 Box {
+                    var showMenu by remember { mutableStateOf(false) }
                     IconButton(onClick = { showMenu = true }) {
                         Icon(Icons.Default.Settings, contentDescription = null)
                     }
-                    DropdownMenu(
-                        expanded = showMenu,
-                        onDismissRequest = { showMenu = false }
-                    ) {
+                    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                        // Theme toggle
                         DropdownMenuItem(
-                            text = { Text(L10n.string("language", appLanguage)) },
+                            text = {
+                                Text(
+                                    if (colorSchemeMode == 1)
+                                        L10n.string("dark", appLanguage)
+                                    else
+                                        L10n.string("light", appLanguage)
+                                )
+                            },
                             onClick = {
                                 showMenu = false
-                                showLanguageSheet = true
+                                onColorSchemeChange(if (colorSchemeMode == 1) 2 else 1)
                             }
                         )
+                        // Language
                         DropdownMenuItem(
-                            text = { Text(L10n.string("reset_records", appLanguage), color = MaterialTheme.colorScheme.error) },
-                            onClick = {
-                                showMenu = false
-                                showResetConfirm = true
-                            }
+                            text = { Text(L10n.string("language", appLanguage)) },
+                            onClick = { showMenu = false; showLanguageSheet = true }
+                        )
+                        // Reset progress
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    L10n.string("reset_progress", appLanguage),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            },
+                            onClick = { showMenu = false; showResetConfirm = true }
                         )
                     }
                 }
@@ -113,91 +102,90 @@ fun MainScreen(
 
             Spacer(modifier = Modifier.weight(1f))
 
-            Text(
-                text = "Math",
-                style = MaterialTheme.typography.headlineLarge,
-                fontSize = 48.sp
-            )
-
-            SingleChoiceSegmentedButtonRow {
-                SegmentedButton(
-                    selected = selectedLevel == GameLevel.EASY,
-                    onClick = { onSelectedLevelChange(GameLevel.EASY) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+            // ── Overall progress ──
+            val overallPct = remember(progressVersion) { (overallProgress() * 100).toInt() }
+            if (overallPct > 0) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(bottom = 8.dp)
                 ) {
-                    Text(L10n.string("level_easy", appLanguage))
-                }
-                SegmentedButton(
-                    selected = selectedLevel == GameLevel.NORMAL,
-                    onClick = { onSelectedLevelChange(GameLevel.NORMAL) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
-                ) {
-                    Text(L10n.string("level_normal", appLanguage))
+                    Text(
+                        L10n.string("overall_progress", appLanguage),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    LinearProgressIndicator(
+                        progress = { overallProgress() },
+                        modifier = Modifier
+                            .fillMaxWidth(0.7f)
+                            .height(6.dp),
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        "$overallPct%",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
 
             Spacer(modifier = Modifier.weight(1f))
 
-            Button(
-                onClick = onStartClick,
+            // ── Resume button ──
+            if (lastStage != null) {
+                val (op, num) = lastStage
+                Button(
+                    onClick = { onResumeClick(lastStage) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(64.dp)
+                        .padding(horizontal = 16.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            L10n.string("resume", appLanguage),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            L10n.string("resume_hint", appLanguage, opName(op, appLanguage), num),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f)
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            // ── New Start button ──
+            OutlinedButton(
+                onClick = onNewStartClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 40.dp),
-                shape = RoundedCornerShape(12.dp)
+                    .height(56.dp)
+                    .padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(16.dp)
             ) {
-                Text(L10n.string("start", appLanguage), fontSize = 20.sp)
-            }
-
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
-                    L10n.string("best_record", appLanguage),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    if (bestTime > 0) L10n.string("time_format", appLanguage, bestTime) else "-",
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = if (bestTime > 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                    L10n.string("new_start", appLanguage),
+                    style = MaterialTheme.typography.titleMedium
                 )
             }
 
             Spacer(modifier = Modifier.weight(1f))
-
-            SingleChoiceSegmentedButtonRow(
-                modifier = Modifier.padding(horizontal = 40.dp)
-            ) {
-                SegmentedButton(
-                    selected = colorSchemeMode == 1,
-                    onClick = { onColorSchemeChange(1) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
-                ) {
-                    Text(L10n.string("light", appLanguage))
-                }
-                SegmentedButton(
-                    selected = colorSchemeMode == 2,
-                    onClick = { onColorSchemeChange(2) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
-                ) {
-                    Text(L10n.string("dark", appLanguage))
-                }
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
         }
 
-        if (showCountdown) {
-            CountdownOverlay(
-                appLanguage = appLanguage,
-                onComplete = {
-                    onShowCountdownChange(false)
-                    onGameActiveChange(true)
-                }
-            )
-        }
-
+        // ── Language picker ──
         if (showLanguageSheet) {
             LanguagePickerSheet(
-                selectedLanguage = appLanguage,
+                selectedLanguage = AppLanguage.fromCode(
+                    appLanguageRaw.ifEmpty { getDeviceLanguageCode() }
+                ),
                 onLanguageSelected = {
                     onAppLanguageChange(it.code)
                     showLanguageSheet = false
@@ -207,21 +195,17 @@ fun MainScreen(
             )
         }
 
+        // ── Reset confirm ──
         if (showResetConfirm) {
             AlertDialog(
                 onDismissRequest = { showResetConfirm = false },
-                title = { Text(L10n.string("reset_confirm_title", appLanguage)) },
-                text = { Text(L10n.string("reset_confirm_message", appLanguage)) },
+                title = { Text(L10n.string("reset_progress_confirm_title", appLanguage)) },
+                text = { Text(L10n.string("reset_progress_confirm_message", appLanguage)) },
                 confirmButton = {
                     Button(
-                        onClick = {
-                            onResetRecords()
-                            showResetConfirm = false
-                        },
+                        onClick = { onResetProgress(); showResetConfirm = false },
                         colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
-                    ) {
-                        Text(L10n.string("reset", appLanguage))
-                    }
+                    ) { Text(L10n.string("reset", appLanguage)) }
                 },
                 dismissButton = {
                     OutlinedButton(onClick = { showResetConfirm = false }) {
@@ -230,46 +214,13 @@ fun MainScreen(
                 }
             )
         }
-
-        if (showHelp) {
-            AlertDialog(
-                onDismissRequest = { showHelp = false },
-                title = { Text(L10n.string("help_title", appLanguage)) },
-                text = {
-                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                        Text(
-                            L10n.string("level_easy", appLanguage),
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            L10n.string("help_easy_desc", appLanguage),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Text(
-                            L10n.string("level_normal", appLanguage),
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            L10n.string("help_normal_desc", appLanguage),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                    }
-                },
-                confirmButton = {
-                    OutlinedButton(onClick = { showHelp = false }) {
-                        Text(L10n.string("cancel", appLanguage))
-                    }
-                }
-            )
-        }
     }
 }
 
+// ─── CountdownOverlay (shared, still used by GameScreen) ─────────────────────
+
 @Composable
-fun CountdownOverlay(
-    appLanguage: AppLanguage,
-    onComplete: () -> Unit
-) {
+fun CountdownOverlay(appLanguage: AppLanguage, onComplete: () -> Unit) {
     var count by remember { mutableIntStateOf(3) }
     var scale by remember { mutableStateOf(0.3f) }
     var alpha by remember { mutableStateOf(0f) }
@@ -309,6 +260,8 @@ fun CountdownOverlay(
     }
 }
 
+// ─── Language picker ──────────────────────────────────────────────────────────
+
 @Composable
 fun LanguagePickerSheet(
     selectedLanguage: AppLanguage,
@@ -322,7 +275,7 @@ fun LanguagePickerSheet(
         text = {
             Column {
                 AppLanguage.entries.forEach { lang ->
-                    androidx.compose.material3.TextButton(
+                    TextButton(
                         onClick = { onLanguageSelected(lang) },
                         modifier = Modifier.fillMaxWidth()
                     ) {

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MathApp.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MathApp.kt
@@ -4,35 +4,39 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.mathapp.practice.ui.theme.MathTheme
 
+// ─── Navigation ───────────────────────────────────────────────────────────────
+
+sealed class Screen {
+    object Home : Screen()
+    object Category : Screen()
+    data class StageMap(val operation: MathOperation) : Screen()
+    data class Game(val operation: MathOperation, val stageNumber: Int) : Screen()
+    data class Result(
+        val operation: MathOperation,
+        val stageNumber: Int,
+        val stars: Int,
+        val correctCount: Int,
+        val avgSeconds: Float
+    ) : Screen()
+}
+
+// ─── Root composable ──────────────────────────────────────────────────────────
+
 @Composable
 fun MathApp() {
     var colorSchemeMode by remember { mutableStateOf(AppSettings.getInt("colorSchemeMode", 1)) }
     var appLanguageRaw by remember { mutableStateOf(AppSettings.getString("appLanguage", "")) }
-    var bestTimeEasy by remember { mutableStateOf(AppSettings.getFloat("bestTimeEasy", 0f)) }
-    var bestTimeNormal by remember { mutableStateOf(AppSettings.getFloat("bestTimeNormal", 0f)) }
-    var selectedLevel by remember { mutableStateOf(GameLevel.NORMAL) }
-    var isGameActive by remember { mutableStateOf(false) }
-    var showCountdown by remember { mutableStateOf(false) }
-
-    val bestTime = if (selectedLevel == GameLevel.EASY) bestTimeEasy else bestTimeNormal
-
-    LaunchedEffect(Unit) {
-        if (bestTimeNormal == 0f) {
-            val legacy = AppSettings.getFloat("bestTime", 0f)
-            if (legacy > 0f) {
-                bestTimeNormal = legacy
-                AppSettings.setFloat("bestTimeNormal", legacy)
-            }
-        }
-    }
+    var screen by remember { mutableStateOf<Screen>(Screen.Home) }
+    // Bump this whenever stage progress changes so child screens re-read AppSettings
+    var progressVersion by remember { mutableIntStateOf(0) }
 
     val appLanguage = when {
         appLanguageRaw.isEmpty() -> AppLanguage.fromCode(getDeviceLanguageCode())
@@ -44,54 +48,80 @@ fun MathApp() {
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background
         ) {
-            if (isGameActive) {
-                GameScreen(
-                    level = selectedLevel,
-                    bestTime = bestTime,
+            when (val s = screen) {
+                is Screen.Home -> HomeScreen(
                     appLanguage = appLanguage,
-                    onComplete = { time ->
-                        if (selectedLevel == GameLevel.EASY) {
-                            if (bestTimeEasy == 0f || time < bestTimeEasy) {
-                                bestTimeEasy = time
-                                AppSettings.setFloat("bestTimeEasy", time)
-                            }
-                        } else {
-                            if (bestTimeNormal == 0f || time < bestTimeNormal) {
-                                bestTimeNormal = time
-                                AppSettings.setFloat("bestTimeNormal", time)
-                            }
-                        }
-                        isGameActive = false
-                    },
-                    onBack = { isGameActive = false }
-                )
-            } else {
-                MainScreen(
                     colorSchemeMode = colorSchemeMode,
                     onColorSchemeChange = {
                         colorSchemeMode = it
                         AppSettings.setInt("colorSchemeMode", it)
                     },
-                    appLanguage = appLanguage,
                     appLanguageRaw = appLanguageRaw,
                     onAppLanguageChange = {
                         appLanguageRaw = it
                         AppSettings.setString("appLanguage", it)
                     },
-                    bestTime = bestTime,
-                    selectedLevel = selectedLevel,
-                    onSelectedLevelChange = { selectedLevel = it },
-                    onStartClick = { showCountdown = true },
-                    showCountdown = showCountdown,
-                    onShowCountdownChange = { showCountdown = it },
-                    onGameActiveChange = { isGameActive = it },
-                    onResetRecords = {
-                        bestTimeEasy = 0f
-                        bestTimeNormal = 0f
-                        AppSettings.setFloat("bestTimeEasy", 0f)
-                        AppSettings.setFloat("bestTimeNormal", 0f)
-                    }
+                    onResumeClick = { (op, num) ->
+                        saveLastPlayedStage(op, num)
+                        screen = Screen.Game(op, num)
+                    },
+                    onNewStartClick = { screen = Screen.Category },
+                    onResetProgress = {
+                        resetAllProgress()
+                        progressVersion++
+                    },
+                    progressVersion = progressVersion
                 )
+
+                is Screen.Category -> CategoryScreen(
+                    appLanguage = appLanguage,
+                    onOperationSelected = { op -> screen = Screen.StageMap(op) },
+                    onBack = { screen = Screen.Home },
+                    progressVersion = progressVersion
+                )
+
+                is Screen.StageMap -> StageMapScreen(
+                    operation = s.operation,
+                    appLanguage = appLanguage,
+                    onStageSelected = { num ->
+                        saveLastPlayedStage(s.operation, num)
+                        screen = Screen.Game(s.operation, num)
+                    },
+                    onBack = { screen = Screen.Category },
+                    progressVersion = progressVersion
+                )
+
+                is Screen.Game -> GameScreen(
+                    operation = s.operation,
+                    stageNumber = s.stageNumber,
+                    appLanguage = appLanguage,
+                    onComplete = { stars, correctCount, avgSec ->
+                        saveStageResult(s.operation, s.stageNumber, stars)
+                        progressVersion++
+                        screen = Screen.Result(s.operation, s.stageNumber, stars, correctCount, avgSec)
+                    },
+                    onBack = { screen = Screen.StageMap(s.operation) }
+                )
+
+                is Screen.Result -> {
+                    val nextNum = s.stageNumber + 1
+                    val hasNextStage = nextNum <= 10 && StageInfo(s.operation, nextNum).isUnlocked
+                    ResultScreen(
+                        operation = s.operation,
+                        stageNumber = s.stageNumber,
+                        stars = s.stars,
+                        correctCount = s.correctCount,
+                        avgSeconds = s.avgSeconds,
+                        appLanguage = appLanguage,
+                        hasNextStage = hasNextStage,
+                        onRetry = { screen = Screen.Game(s.operation, s.stageNumber) },
+                        onNextStage = {
+                            if (hasNextStage) screen = Screen.Game(s.operation, nextNum)
+                            else screen = Screen.StageMap(s.operation)
+                        },
+                        onToStageMap = { screen = Screen.StageMap(s.operation) }
+                    )
+                }
             }
         }
     }

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/NumberKeypad.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/NumberKeypad.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.sp
 fun NumberKeypad(
     modifier: Modifier = Modifier,
     confirmTitle: String,
+    showMinus: Boolean = true,
     onDigit: (String) -> Unit,
     onBackspace: () -> Unit,
     onSubmit: () -> Unit,
@@ -35,7 +36,7 @@ fun NumberKeypad(
             listOf("1", "2", "3"),
             listOf("4", "5", "6"),
             listOf("7", "8", "9"),
-            listOf("-", "0", "⌫")
+            listOf(if (showMinus) "-" else "", "0", "⌫")
         ).forEach { row ->
             Row(
                 modifier = Modifier
@@ -48,11 +49,13 @@ fun NumberKeypad(
                     KeypadButton(
                         text = key,
                         isSpecial = isSpecial,
+                        enabled = key.isNotEmpty(),
                         modifier = Modifier.weight(1f)
                     ) {
                         when (key) {
                             "-" -> onMinus()
                             "⌫" -> onBackspace()
+                            "" -> {}
                             else -> onDigit(key)
                         }
                     }
@@ -77,16 +80,19 @@ fun KeypadButton(
     modifier: Modifier = Modifier,
     isSpecial: Boolean = false,
     isAccent: Boolean = false,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     Surface(
         modifier = modifier.height(50.dp),
         onClick = onClick,
+        enabled = enabled,
         shape = RoundedCornerShape(10.dp),
         color = when {
-            isAccent -> MaterialTheme.colorScheme.primary
+            !enabled  -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+            isAccent  -> MaterialTheme.colorScheme.primary
             isSpecial -> MaterialTheme.colorScheme.surfaceVariant
-            else -> MaterialTheme.colorScheme.surface
+            else      -> MaterialTheme.colorScheme.surface
         }
     ) {
         androidx.compose.foundation.layout.Box(

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/ResultScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/ResultScreen.kt
@@ -1,0 +1,261 @@
+package com.mathapp.practice.ui
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.sin
+import kotlin.random.Random
+
+@Composable
+fun ResultScreen(
+    operation: MathOperation,
+    stageNumber: Int,
+    stars: Int,
+    correctCount: Int,
+    avgSeconds: Float,
+    appLanguage: AppLanguage,
+    hasNextStage: Boolean,
+    onRetry: () -> Unit,
+    onNextStage: () -> Unit,
+    onToStageMap: () -> Unit
+) {
+    val titleKey = when (stars) {
+        3    -> "result_title_3star"
+        2    -> "result_title_2star"
+        else -> "result_title_1star"
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Confetti for 3 stars
+        if (stars == 3) {
+            ConfettiView(modifier = Modifier.fillMaxSize())
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Stage label
+            Text(
+                "${opName(operation, appLanguage)} ${L10n.string("stage_num_format", appLanguage, stageNumber)}",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Title
+            Text(
+                L10n.string(titleKey, appLanguage),
+                style = MaterialTheme.typography.headlineLarge,
+                fontSize = 36.sp,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Animated stars
+            StarDisplay(stars = stars)
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            // Stats card
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.fillMaxWidth(0.8f)
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        L10n.string("correct_format", appLanguage, correctCount),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        L10n.string("avg_time_format", appLanguage, avgSeconds),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Star condition hints
+            Column(
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier.fillMaxWidth(0.8f)
+            ) {
+                listOf("star_cond_3", "star_cond_2", "star_cond_1").forEachIndexed { idx, key ->
+                    val condStars = 3 - idx
+                    Text(
+                        L10n.string(key, appLanguage),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (stars >= condStars)
+                            MaterialTheme.colorScheme.primary
+                        else
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Action buttons
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                // "스테이지 맵으로" — always visible
+                OutlinedButton(
+                    onClick = onToStageMap,
+                    modifier = Modifier.fillMaxWidth().height(52.dp),
+                    shape = RoundedCornerShape(14.dp)
+                ) {
+                    Text(L10n.string("to_stage_map", appLanguage), style = MaterialTheme.typography.titleMedium)
+                }
+
+                // "다시 하기" — always visible
+                OutlinedButton(
+                    onClick = onRetry,
+                    modifier = Modifier.fillMaxWidth().height(52.dp),
+                    shape = RoundedCornerShape(14.dp)
+                ) {
+                    Text(L10n.string("retry", appLanguage), style = MaterialTheme.typography.titleMedium)
+                }
+
+                // "다음 단계로" — only if next stage unlocked (primary action)
+                if (hasNextStage) {
+                    Button(
+                        onClick = onNextStage,
+                        modifier = Modifier.fillMaxWidth().height(52.dp),
+                        shape = RoundedCornerShape(14.dp)
+                    ) {
+                        Text(L10n.string("next_stage", appLanguage), style = MaterialTheme.typography.titleMedium)
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+// ─── Animated star display ────────────────────────────────────────────────────
+
+@Composable
+private fun StarDisplay(stars: Int) {
+    val scale1 = remember { Animatable(0f) }
+    val scale2 = remember { Animatable(0f) }
+    val scale3 = remember { Animatable(0f) }
+
+    LaunchedEffect(stars) {
+        kotlinx.coroutines.delay(300)
+        scale1.animateTo(1f, animationSpec = spring(dampingRatio = 0.4f, stiffness = 300f))
+        if (stars >= 2) {
+            kotlinx.coroutines.delay(150)
+            scale2.animateTo(1f, animationSpec = spring(dampingRatio = 0.4f, stiffness = 300f))
+        }
+        if (stars >= 3) {
+            kotlinx.coroutines.delay(150)
+            scale3.animateTo(1f, animationSpec = spring(dampingRatio = 0.4f, stiffness = 300f))
+        }
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val emptyAlpha = 0.2f
+        // Star 2 (left, slightly smaller when inactive — middle-left-right order for visual appeal)
+        Text(
+            "⭐",
+            fontSize = 42.sp,
+            modifier = Modifier.scale(if (stars >= 2) scale2.value else 1f),
+            color = if (stars >= 2) Color.Unspecified
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = emptyAlpha)
+        )
+        // Star 1 (center, slightly larger)
+        Text(
+            "⭐",
+            fontSize = 52.sp,
+            modifier = Modifier.scale(scale1.value),
+            color = if (stars >= 1) Color.Unspecified
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = emptyAlpha)
+        )
+        // Star 3 (right)
+        Text(
+            "⭐",
+            fontSize = 42.sp,
+            modifier = Modifier.scale(if (stars >= 3) scale3.value else 1f),
+            color = if (stars >= 3) Color.Unspecified
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = emptyAlpha)
+        )
+    }
+}
+
+// ─── Confetti (3-star celebration) ───────────────────────────────────────────
+
+@Composable
+fun ConfettiView(modifier: Modifier = Modifier) {
+    val startTime = remember { currentTimeMillis() }
+    var elapsed by remember { mutableFloatStateOf(0f) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            kotlinx.coroutines.delay(16)
+            elapsed = (currentTimeMillis() - startTime) / 1000f
+        }
+    }
+    val particles = remember {
+        List(80) { i ->
+            ConfettiParticle(
+                startX = Random.nextFloat(),
+                startY = 1f + Random.nextFloat() * 0.2f,
+                size = (8 + Random.nextInt(11)).toFloat(),
+                color = listOf(
+                    Color(0xFF, 0x69, 0xB4), Color(0xFF, 0x8C, 0x00), Color(0xFF, 0xFF, 0x00),
+                    Color(0x00, 0xFF, 0x00), Color(0x98, 0xFB, 0x98), Color(0x00, 0xFF, 0xFF),
+                    Color(0x00, 0x00, 0xFF), Color(0x8A, 0x2B, 0xE2), Color(0xFF, 0x00, 0x00)
+                ).random(),
+                startDelay = i * 0.05f,
+                speed = 100f + Random.nextFloat() * 120f,
+                drift = -120f + Random.nextFloat() * 240f
+            )
+        }
+    }
+    Canvas(modifier = modifier) {
+        val w = size.width
+        val h = size.height
+        particles.forEach { p ->
+            val t = maxOf(0f, elapsed - p.startDelay)
+            val y = (p.startY * h) - (p.speed * t)
+            val x = (p.startX * w) + (p.drift * t * 0.25f) + (sin(t.toDouble() * 2.5).toFloat() * 25f)
+            if (y > -50) {
+                drawCircle(color = p.color.copy(alpha = 0.85f), radius = p.size, center = Offset(x, y))
+            }
+        }
+    }
+}
+
+private data class ConfettiParticle(
+    val startX: Float, val startY: Float, val size: Float, val color: Color,
+    val startDelay: Float, val speed: Float, val drift: Float
+)

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageData.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageData.kt
@@ -1,0 +1,270 @@
+package com.mathapp.practice.ui
+
+import kotlin.random.Random
+
+// ─── Operations ───────────────────────────────────────────────────────────────
+
+enum class MathOperation(val symbol: String, val key: String) {
+    ADDITION("+", "add"),
+    SUBTRACTION("-", "sub"),
+    MULTIPLICATION("×", "mul"),
+    DIVISION("÷", "div")
+}
+
+// ─── MathProblem ──────────────────────────────────────────────────────────────
+
+data class MathProblem(val num1: Int, val num2: Int, val op: String) {
+    val answer: Int = when (op) {
+        "+" -> num1 + num2
+        "-" -> num1 - num2
+        "×" -> num1 * num2
+        "÷" -> if (num2 != 0) num1 / num2 else 0
+        else -> 0
+    }
+    val displayText: String = "$num1 $op $num2"
+}
+
+// ─── Stage info ───────────────────────────────────────────────────────────────
+
+data class StageInfo(val operation: MathOperation, val number: Int) {
+    private val settingsKey: String get() = "${operation.key}_${number}"
+
+    // Stage 1 of every operation is always available
+    val isUnlocked: Boolean
+        get() = if (number == 1) true
+                else AppSettings.getInt("stage_${settingsKey}_unlocked", 0) == 1
+
+    val stars: Int
+        get() = AppSettings.getInt("stage_${settingsKey}_stars", 0)
+
+    fun desc(lang: AppLanguage): String = stageDesc(operation, number, lang)
+}
+
+val ALL_STAGES: List<StageInfo> = MathOperation.entries.flatMap { op ->
+    (1..10).map { n -> StageInfo(op, n) }
+}
+
+fun stagesFor(op: MathOperation): List<StageInfo> = (1..10).map { StageInfo(op, it) }
+
+// ─── Progress persistence ─────────────────────────────────────────────────────
+
+fun saveStageResult(op: MathOperation, number: Int, stars: Int) {
+    val key = "${op.key}_${number}"
+    AppSettings.setInt("stage_${key}_unlocked", 1)
+    val prev = AppSettings.getInt("stage_${key}_stars", 0)
+    if (stars > prev) AppSettings.setInt("stage_${key}_stars", stars)
+    // Unlock next stage on any clear (≥1 star)
+    if (stars >= 1) {
+        val nextNum = number + 1
+        if (nextNum <= 10) {
+            AppSettings.setInt("stage_${op.key}_${nextNum}_unlocked", 1)
+        } else {
+            val ops = MathOperation.entries
+            val nextIdx = ops.indexOf(op) + 1
+            if (nextIdx < ops.size) {
+                // Next operation's stage 1 is always unlocked anyway,
+                // but mark it explicitly so the UI can signal progress
+                AppSettings.setInt("stage_${ops[nextIdx].key}_1_unlocked", 1)
+            }
+        }
+    }
+}
+
+fun getLastPlayedStage(): Pair<MathOperation, Int>? {
+    val opKey = AppSettings.getString("last_op", "")
+    val num = AppSettings.getInt("last_stage_num", 0)
+    if (opKey.isEmpty() || num == 0) return null
+    return MathOperation.entries.find { it.key == opKey }?.let { Pair(it, num) }
+}
+
+fun saveLastPlayedStage(op: MathOperation, number: Int) {
+    AppSettings.setString("last_op", op.key)
+    AppSettings.setInt("last_stage_num", number)
+}
+
+fun resetAllProgress() {
+    MathOperation.entries.forEach { op ->
+        (1..10).forEach { n ->
+            AppSettings.setInt("stage_${op.key}_${n}_unlocked", 0)
+            AppSettings.setInt("stage_${op.key}_${n}_stars", 0)
+        }
+    }
+    AppSettings.setString("last_op", "")
+    AppSettings.setInt("last_stage_num", 0)
+}
+
+// ─── Star calculation ─────────────────────────────────────────────────────────
+
+/** correctCount = number of problems answered correctly on first attempt (0-10).
+ *  totalSeconds  = total elapsed wall-clock seconds for the full game. */
+fun calcStars(correctCount: Int, totalSeconds: Float): Int {
+    val avg = totalSeconds / 10f
+    return when {
+        correctCount == 10 && avg <= 3f -> 3
+        correctCount >= 8               -> 2
+        else                            -> 1
+    }
+}
+
+// ─── Aggregate progress ───────────────────────────────────────────────────────
+
+fun overallProgress(): Float {
+    val cleared = ALL_STAGES.count { it.stars > 0 }
+    return cleared.toFloat() / ALL_STAGES.size.toFloat()
+}
+
+fun operationProgress(op: MathOperation): Float {
+    val stages = stagesFor(op)
+    return stages.count { it.stars > 0 }.toFloat() / stages.size.toFloat()
+}
+
+// ─── Problem generation ───────────────────────────────────────────────────────
+
+fun generateProblems(op: MathOperation, stageNumber: Int): List<MathProblem> =
+    List(10) { generateOneProblem(op, stageNumber) }
+
+private fun generateOneProblem(op: MathOperation, stage: Int): MathProblem = when (op) {
+    MathOperation.ADDITION       -> generateAddition(stage)
+    MathOperation.SUBTRACTION    -> generateSubtraction(stage)
+    MathOperation.MULTIPLICATION -> generateMultiplication(stage)
+    MathOperation.DIVISION       -> generateDivision(stage)
+}
+
+private fun generateAddition(stage: Int): MathProblem {
+    val (a, b) = when (stage) {
+        1    -> { val a = Random.nextInt(0, 6);  Pair(a, Random.nextInt(0, 5 - a + 1)) }   // sum ≤ 5
+        2    -> { val a = Random.nextInt(1, 9);  Pair(a, Random.nextInt(1, 9 - a + 1)) }   // sum ≤ 9
+        3    -> { val a = Random.nextInt(1, 10); Pair(a, 10 - a) }                          // make 10
+        4    -> { val a = Random.nextInt(2, 15); Pair(a, Random.nextInt(2, 21 - a)) }       // sum ≤ 20
+        5    -> { val a = Random.nextInt(10, 90); Pair(a, Random.nextInt(1, 100 - a)) }     // 2-digit general
+        6    -> {                                                                             // 2-digit + 1-digit with carry
+            val onesA = Random.nextInt(2, 9)
+            val b2 = Random.nextInt(10 - onesA, 10)
+            Pair(Random.nextInt(1, 9) * 10 + onesA, b2)
+        }
+        7    -> { val a = Random.nextInt(10, 70); Pair(a, Random.nextInt(10, 100 - a)) }    // 2-digit + 2-digit
+        8    -> { Pair(Random.nextInt(100, 990), Random.nextInt(1, 10)) }                    // 3-digit + 1-digit
+        9    -> { Pair(Random.nextInt(100, 900), Random.nextInt(10, 100)) }                  // 3-digit + 2-digit
+        else -> { val a = Random.nextInt(100, 900); Pair(a, Random.nextInt(1, 100)) }       // mixed large
+    }
+    return MathProblem(a, b, "+")
+}
+
+private fun generateSubtraction(stage: Int): MathProblem {
+    val (a, b) = when (stage) {
+        1    -> { val res = Random.nextInt(0, 6); val b = Random.nextInt(0, 6 - res); Pair(res + b, b) } // result ≤ 5
+        2    -> { val a = Random.nextInt(1, 10); Pair(a, Random.nextInt(0, a + 1)) }                      // single-digit
+        3    -> { val a = Random.nextInt(10, 20); Pair(a, Random.nextInt(1, a)) }                         // from teens
+        4    -> { val a = Random.nextInt(10, 30); Pair(a, Random.nextInt(1, a)) }                         // borrowing
+        5    -> { val a = Random.nextInt(10, 100); Pair(a, Random.nextInt(0, a + 1)) }                    // 2-digit general
+        6    -> {                                                                                           // 2-digit - 1-digit with borrow
+            val onesA = Random.nextInt(0, 8)
+            val b2 = Random.nextInt(onesA + 1, 10)
+            Pair(Random.nextInt(1, 10) * 10 + onesA, b2)
+        }
+        7    -> { val a = Random.nextInt(20, 100); Pair(a, Random.nextInt(10, a)) }                       // 2-digit - 2-digit
+        8    -> { Pair(Random.nextInt(100, 999), Random.nextInt(1, 10)) }                                  // 3-digit - 1-digit
+        9    -> { val a = Random.nextInt(100, 999); Pair(a, Random.nextInt(10, a - 9)) }                  // 3-digit - 2-digit
+        else -> { val a = Random.nextInt(100, 999); Pair(a, Random.nextInt(1, a + 1)) }                   // mixed large
+    }
+    return MathProblem(a, b, "-")
+}
+
+private fun generateMultiplication(stage: Int): MathProblem {
+    // Stages 8-10: two-digit × single-digit
+    if (stage >= 8) {
+        val (a, b) = when (stage) {
+            8    -> Pair(Random.nextInt(10, 30), Random.nextInt(2, 4))   // 2-digit × 1~3
+            9    -> Pair(Random.nextInt(10, 20), Random.nextInt(4, 7))   // 2-digit × 4~6
+            else -> Pair(Random.nextInt(11, 16), Random.nextInt(7, 10))  // 2-digit × 7~9
+        }
+        return if (Random.nextBoolean()) MathProblem(a, b, "×") else MathProblem(b, a, "×")
+    }
+    val m = when (stage) {
+        1    -> Random.nextInt(1, 3)   // ×1, ×2
+        2    -> Random.nextInt(3, 5)   // ×3, ×4
+        3    -> Random.nextInt(5, 7)   // ×5, ×6
+        4    -> Random.nextInt(7, 9)   // ×7, ×8
+        5    -> 9                      // ×9
+        6    -> Random.nextInt(1, 6)   // ×1~×5 mixed
+        else -> Random.nextInt(6, 10)  // ×6~×9 mixed (stage 7)
+    }
+    val n = Random.nextInt(1, 10)
+    return if (Random.nextBoolean()) MathProblem(m, n, "×") else MathProblem(n, m, "×")
+}
+
+private fun generateDivision(stage: Int): MathProblem {
+    val (divisors, maxQuotient) = when (stage) {
+        1    -> Pair(listOf(2, 3), 9)
+        2    -> Pair(listOf(4, 5), 9)
+        3    -> Pair(listOf(6, 7), 9)
+        4    -> Pair(listOf(8, 9), 9)
+        5    -> Pair((2..5).toList(), 9)    // ÷2~÷5 mixed
+        6    -> Pair((6..9).toList(), 9)    // ÷6~÷9 mixed
+        7    -> Pair((2..9).toList(), 9)    // ÷2~÷9 mixed
+        8    -> Pair((2..5).toList(), 12)   // large ÷2~÷5
+        9    -> Pair((6..9).toList(), 12)   // large ÷6~÷9
+        else -> Pair((2..9).toList(), 12)   // mixed large
+    }
+    val b = divisors.random()
+    return MathProblem(b * Random.nextInt(1, maxQuotient + 1), b, "÷")
+}
+
+// ─── Stage descriptions (per language) ───────────────────────────────────────
+
+fun stageDesc(op: MathOperation, stage: Int, lang: AppLanguage): String {
+    val list = when (op) {
+        MathOperation.ADDITION -> when (lang) {
+            AppLanguage.KOREAN             -> listOf("합이 5 이하", "합이 9 이하", "10 만들기", "합이 20 이하", "두 자리 덧셈", "받아올림 덧셈", "두 자리끼리 덧셈", "세 자리+한 자리", "세 자리+두 자리", "혼합 덧셈")
+            AppLanguage.JAPANESE           -> listOf("合計5以下", "合計9以下", "10の合成", "合計20以下", "2桁のたし算", "繰り上がりあり", "2桁+2桁", "3桁+1桁", "3桁+2桁", "混合たし算")
+            AppLanguage.CHINESE_TRADITIONAL-> listOf("和≤5", "和≤9", "湊成10", "和≤20", "兩位數加法", "進位加法", "兩位+兩位", "三位+個位", "三位+兩位", "混合加法")
+            AppLanguage.CHINESE_SIMPLIFIED -> listOf("和≤5", "和≤9", "凑成10", "和≤20", "两位数加法", "进位加法", "两位+两位", "三位+个位", "三位+两位", "混合加法")
+            else                           -> listOf("Sum ≤ 5", "Sum ≤ 9", "Make 10", "Sum ≤ 20", "Two-digit", "With carry", "2-digit + 2-digit", "3-digit + 1-digit", "3-digit + 2-digit", "Mixed")
+        }
+        MathOperation.SUBTRACTION -> when (lang) {
+            AppLanguage.KOREAN             -> listOf("결과가 5 이하", "한 자리 뺄셈", "십의 자리 뺄셈", "받아내림", "두 자리 뺄셈", "받아내림 뺄셈", "두 자리끼리 뺄셈", "세 자리-한 자리", "세 자리-두 자리", "혼합 뺄셈")
+            AppLanguage.JAPANESE           -> listOf("結果5以下", "1桁のひき算", "10台のひき算", "繰り下がり", "2桁のひき算", "繰り下がりあり", "2桁-2桁", "3桁-1桁", "3桁-2桁", "混合ひき算")
+            AppLanguage.CHINESE_TRADITIONAL-> listOf("結果≤5", "個位數減法", "十位數減法", "借位減法", "兩位數減法", "借位進階", "兩位-兩位", "三位-個位", "三位-兩位", "混合減法")
+            AppLanguage.CHINESE_SIMPLIFIED -> listOf("结果≤5", "个位数减法", "十位数减法", "借位减法", "两位数减法", "借位进阶", "两位-两位", "三位-个位", "三位-两位", "混合减法")
+            else                           -> listOf("Result ≤ 5", "Single-digit", "From teens", "Borrowing", "Two-digit", "With borrow", "2-digit - 2-digit", "3-digit - 1-digit", "3-digit - 2-digit", "Mixed")
+        }
+        MathOperation.MULTIPLICATION -> when (lang) {
+            AppLanguage.KOREAN             -> listOf("×1, ×2", "×3, ×4", "×5, ×6", "×7, ×8", "×9", "×1~×5 혼합", "×6~×9 혼합", "두 자리×1~3", "두 자리×4~6", "두 자리×7~9")
+            AppLanguage.JAPANESE           -> listOf("×1, ×2", "×3, ×4", "×5, ×6", "×7, ×8", "×9", "×1~×5 混合", "×6~×9 混合", "2桁×1~3", "2桁×4~6", "2桁×7~9")
+            AppLanguage.CHINESE_TRADITIONAL-> listOf("×1, ×2", "×3, ×4", "×5, ×6", "×7, ×8", "×9", "×1~×5 混合", "×6~×9 混合", "兩位×1~3", "兩位×4~6", "兩位×7~9")
+            AppLanguage.CHINESE_SIMPLIFIED -> listOf("×1, ×2", "×3, ×4", "×5, ×6", "×7, ×8", "×9", "×1~×5 混合", "×6~×9 混合", "两位×1~3", "两位×4~6", "两位×7~9")
+            else                           -> listOf("×1, ×2", "×3, ×4", "×5, ×6", "×7, ×8", "×9", "×1~×5 mixed", "×6~×9 mixed", "2-digit × 1~3", "2-digit × 4~6", "2-digit × 7~9")
+        }
+        MathOperation.DIVISION -> when (lang) {
+            AppLanguage.KOREAN             -> listOf("÷2, ÷3", "÷4, ÷5", "÷6, ÷7", "÷8, ÷9", "÷2~÷5 혼합", "÷6~÷9 혼합", "÷2~÷9 혼합", "큰 수 ÷2~÷5", "큰 수 ÷6~÷9", "혼합 나눗셈")
+            AppLanguage.JAPANESE           -> listOf("÷2, ÷3", "÷4, ÷5", "÷6, ÷7", "÷8, ÷9", "÷2~÷5 混合", "÷6~÷9 混合", "÷2~÷9 混合", "大きな数÷2~5", "大きな数÷6~9", "混合わり算")
+            AppLanguage.CHINESE_TRADITIONAL-> listOf("÷2, ÷3", "÷4, ÷5", "÷6, ÷7", "÷8, ÷9", "÷2~÷5 混合", "÷6~÷9 混合", "÷2~÷9 混合", "大數÷2~÷5", "大數÷6~÷9", "混合除法")
+            AppLanguage.CHINESE_SIMPLIFIED -> listOf("÷2, ÷3", "÷4, ÷5", "÷6, ÷7", "÷8, ÷9", "÷2~÷5 混合", "÷6~÷9 混合", "÷2~÷9 混合", "大数÷2~÷5", "大数÷6~÷9", "混合除法")
+            else                           -> listOf("÷2, ÷3", "÷4, ÷5", "÷6, ÷7", "÷8, ÷9", "÷2~÷5 mixed", "÷6~÷9 mixed", "÷2~÷9 mixed", "Large ÷2~÷5", "Large ÷6~÷9", "Mixed ÷2~÷9")
+        }
+    }
+    return list.getOrElse(stage - 1) { "Stage $stage" }
+}
+
+fun opName(op: MathOperation, lang: AppLanguage): String = when (op) {
+    MathOperation.ADDITION -> when (lang) {
+        AppLanguage.KOREAN -> "덧셈"; AppLanguage.JAPANESE -> "たし算"
+        AppLanguage.CHINESE_TRADITIONAL, AppLanguage.CHINESE_SIMPLIFIED -> "加法"
+        else -> "Addition"
+    }
+    MathOperation.SUBTRACTION -> when (lang) {
+        AppLanguage.KOREAN -> "뺄셈"; AppLanguage.JAPANESE -> "ひき算"
+        AppLanguage.CHINESE_TRADITIONAL, AppLanguage.CHINESE_SIMPLIFIED -> "減法"
+        else -> "Subtraction"
+    }
+    MathOperation.MULTIPLICATION -> when (lang) {
+        AppLanguage.KOREAN -> "곱셈"; AppLanguage.JAPANESE -> "かけ算"
+        AppLanguage.CHINESE_TRADITIONAL, AppLanguage.CHINESE_SIMPLIFIED -> "乘法"
+        else -> "Multiplication"
+    }
+    MathOperation.DIVISION -> when (lang) {
+        AppLanguage.KOREAN -> "나눗셈"; AppLanguage.JAPANESE -> "わり算"
+        AppLanguage.CHINESE_TRADITIONAL, AppLanguage.CHINESE_SIMPLIFIED -> "除法"
+        else -> "Division"
+    }
+}

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageMapScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageMapScreen.kt
@@ -1,0 +1,212 @@
+package com.mathapp.practice.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun StageMapScreen(
+    operation: MathOperation,
+    appLanguage: AppLanguage,
+    onStageSelected: (Int) -> Unit,
+    onBack: () -> Unit,
+    progressVersion: Int
+) {
+    val stages = remember(progressVersion) { stagesFor(operation) }
+    // "Current" stage = first unlocked stage with 0 stars, else last stage
+    val currentIdx = stages.indexOfFirst { it.isUnlocked && it.stars == 0 }
+        .let { if (it == -1) stages.size - 1 else it }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // ── Top bar ──
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+            }
+            Text(
+                "${opName(operation, appLanguage)} — ${L10n.string("stage_map_title", appLanguage)}",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.width(48.dp))
+        }
+
+        // ── Stage nodes ──
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 32.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(0.dp)
+        ) {
+            stages.forEachIndexed { idx, stage ->
+                val isCurrent = idx == currentIdx
+                val isLocked = !stage.isUnlocked
+
+                if (idx > 0) {
+                    ConnectorLine(locked = isLocked)
+                }
+
+                StageNode(
+                    stage = stage,
+                    stageNumber = idx + 1,
+                    isCurrent = isCurrent,
+                    appLanguage = appLanguage,
+                    onClick = if (isLocked) null else ({ onStageSelected(stage.number) })
+                )
+            }
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun ConnectorLine(locked: Boolean) {
+    val color = if (locked)
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)
+    else
+        MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)
+
+    Canvas(
+        modifier = Modifier
+            .width(4.dp)
+            .height(36.dp)
+    ) {
+        drawLine(
+            color = color,
+            start = Offset(size.width / 2f, 0f),
+            end = Offset(size.width / 2f, size.height),
+            strokeWidth = size.width,
+            cap = StrokeCap.Round,
+            pathEffect = if (locked) PathEffect.dashPathEffect(floatArrayOf(8f, 8f)) else null
+        )
+    }
+}
+
+@Composable
+private fun StageNode(
+    stage: StageInfo,
+    stageNumber: Int,
+    isCurrent: Boolean,
+    appLanguage: AppLanguage,
+    onClick: (() -> Unit)?
+) {
+    val isLocked = !stage.isUnlocked
+    val nodeSize = if (isCurrent) 80.dp else 64.dp
+    val bgColor = when {
+        isLocked  -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        stage.stars == 3 -> MaterialTheme.colorScheme.primary
+        stage.stars > 0  -> MaterialTheme.colorScheme.secondary
+        isCurrent        -> MaterialTheme.colorScheme.primaryContainer
+        else             -> MaterialTheme.colorScheme.surfaceVariant
+    }
+    val contentColor = when {
+        isLocked -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+        stage.stars == 3 -> MaterialTheme.colorScheme.onPrimary
+        stage.stars > 0  -> MaterialTheme.colorScheme.onSecondary
+        isCurrent        -> MaterialTheme.colorScheme.onPrimaryContainer
+        else             -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        // Node circle
+        Surface(
+            modifier = Modifier.size(nodeSize),
+            shape = CircleShape,
+            color = bgColor,
+            onClick = { onClick?.invoke() },
+            enabled = onClick != null,
+            tonalElevation = if (isCurrent) 6.dp else 0.dp
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                if (isLocked) {
+                    Text("🔒", fontSize = if (isCurrent) 28.sp else 22.sp)
+                } else if (stage.stars > 0) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            starsString(stage.stars),
+                            fontSize = if (isCurrent) 20.sp else 16.sp
+                        )
+                    }
+                } else {
+                    Text(
+                        stageNumber.toString(),
+                        fontSize = if (isCurrent) 32.sp else 24.sp,
+                        color = contentColor,
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                }
+            }
+        }
+
+        // Stage info
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = L10n.string("stage_num_format", appLanguage, stageNumber),
+                    style = if (isCurrent) MaterialTheme.typography.titleMedium
+                            else MaterialTheme.typography.bodyMedium,
+                    color = if (isLocked)
+                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                    else
+                        MaterialTheme.colorScheme.onSurface
+                )
+                if (isCurrent && !isLocked) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Surface(
+                        shape = RoundedCornerShape(6.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer
+                    ) {
+                        Text(
+                            "▶",
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                }
+            }
+            Text(
+                text = stage.desc(appLanguage),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isLocked)
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+                else
+                    MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun starsString(stars: Int): String = when (stars) {
+    1 -> "⭐"
+    2 -> "⭐⭐"
+    3 -> "⭐⭐⭐"
+    else -> ""
+}


### PR DESCRIPTION
## 요약
- 최고 기록 경쟁 중심 흐름을 제거하고 이어하기/진척도 중심 홈 화면으로 전환했습니다.
- 연산 선택, 스테이지 맵, 결과 화면을 추가해 4개 연산 x 10단계 성장형 진행 구조를 도입했습니다.
- 스테이지별 문제 생성, 별점 산정, 잠금 해제, 마지막 플레이 저장 로직을 shared UI 계층에 통합했습니다.

## 주요 변경 사항
- `MathApp`에 홈 > 연산 선택 > 스테이지 맵 > 게임 > 결과 화면 네비게이션을 추가했습니다.
- `GameScreen`을 스테이지 기반 플레이 흐름으로 개편하고, 첫 시도 정답 수/평균 시간 기반 결과 계산을 연결했습니다.
- `StageData`를 도입해 연산별 스테이지 정의, 문제 생성, 별점 계산, 전체 진척도 집계를 구현했습니다.
- `NumberKeypad`를 연산별 입력 제어가 가능하도록 보강하고, 결과/진척도 관련 다국어 문자열을 추가했습니다.
- 카테고리 화면의 진행도 표시를 실제 10단계 기준으로 보정했습니다.

## 테스트
- `./gradlew clean :app:assembleDebug`

## 리뷰 포인트
- 스테이지 해금 규칙과 별점 조건이 기획 의도와 맞는지
- 홈/스테이지 맵/결과 화면 사이의 사용자 흐름이 자연스러운지
- 연산별 문제 난이도 분배가 기대한 학습 곡선과 맞는지