### PR TITLE
feat: 포인트 보상 및 하트 에너지 시스템 도입, 3-star 밸런스 조정

### DIFF
--- a/android/shared/src/androidMain/kotlin/com/mathapp/practice/ui/PlatformUtils.android.kt
+++ b/android/shared/src/androidMain/kotlin/com/mathapp/practice/ui/PlatformUtils.android.kt
@@ -16,6 +16,8 @@ actual fun getDeviceLanguageCode(): String {
 
 actual fun currentTimeMillis(): Long = System.currentTimeMillis()
 
+actual fun getCurrentEpochSeconds(): Long = System.currentTimeMillis() / 1000
+
 private var hardwareOnDigit: ((String) -> Unit)? = null
 private var hardwareOnBackspace: (() -> Unit)? = null
 private var hardwareOnSubmit: (() -> Unit)? = null

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/Localization.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/Localization.kt
@@ -63,9 +63,13 @@ object L10n {
             "retry" to "다시 하기",
             "next_stage" to "다음 단계로",
             "to_stage_map" to "스테이지 맵으로",
-            "star_cond_3" to "⭐⭐⭐  만점 + 평균 3초 이하",
+            "star_cond_3" to "⭐⭐⭐  만점 + 평균 6초 이하",
             "star_cond_2" to "⭐⭐  8문제 이상 정답",
-            "star_cond_1" to "⭐  완주 성공"
+            "star_cond_1" to "⭐  완주 성공",
+            "points_earned" to "%d P 획득!",
+            "hearts_display" to "❤️ %d / %d",
+            "next_heart_timer" to "+1 %02d:%02d",
+            "total_points_format" to "누적 %d P"
         ),
         AppLanguage.ENGLISH to mapOf(
             "reset_records" to "Reset Records",
@@ -116,9 +120,13 @@ object L10n {
             "retry" to "Try Again",
             "next_stage" to "Next Stage",
             "to_stage_map" to "Stage Map",
-            "star_cond_3" to "⭐⭐⭐  Perfect score + avg ≤ 3s",
+            "star_cond_3" to "⭐⭐⭐  Perfect score + avg ≤ 6s",
             "star_cond_2" to "⭐⭐  8 or more correct",
-            "star_cond_1" to "⭐  Finish all 10"
+            "star_cond_1" to "⭐  Finish all 10",
+            "points_earned" to "%d P earned!",
+            "hearts_display" to "❤️ %d / %d",
+            "next_heart_timer" to "+1 %02d:%02d",
+            "total_points_format" to "Total %d P"
         ),
         AppLanguage.CHINESE_TRADITIONAL to mapOf(
             "reset_records" to "重置紀錄",
@@ -169,9 +177,13 @@ object L10n {
             "retry" to "再試一次",
             "next_stage" to "下一關",
             "to_stage_map" to "關卡地圖",
-            "star_cond_3" to "⭐⭐⭐  滿分 + 平均≤3秒",
+            "star_cond_3" to "⭐⭐⭐  滿分 + 平均≤6秒",
             "star_cond_2" to "⭐⭐  答對8題以上",
-            "star_cond_1" to "⭐  完成全部題目"
+            "star_cond_1" to "⭐  完成全部題目",
+            "points_earned" to "獲得 %d P！",
+            "hearts_display" to "❤️ %d / %d",
+            "next_heart_timer" to "+1 %02d:%02d",
+            "total_points_format" to "累計 %d P"
         ),
         AppLanguage.CHINESE_SIMPLIFIED to mapOf(
             "reset_records" to "重置记录",
@@ -222,9 +234,13 @@ object L10n {
             "retry" to "再试一次",
             "next_stage" to "下一关",
             "to_stage_map" to "关卡地图",
-            "star_cond_3" to "⭐⭐⭐  满分 + 平均≤3秒",
+            "star_cond_3" to "⭐⭐⭐  满分 + 平均≤6秒",
             "star_cond_2" to "⭐⭐  答对8题以上",
-            "star_cond_1" to "⭐  完成全部题目"
+            "star_cond_1" to "⭐  完成全部题目",
+            "points_earned" to "获得 %d P！",
+            "hearts_display" to "❤️ %d / %d",
+            "next_heart_timer" to "+1 %02d:%02d",
+            "total_points_format" to "累计 %d P"
         ),
         AppLanguage.JAPANESE to mapOf(
             "reset_records" to "記録をリセット",
@@ -275,9 +291,13 @@ object L10n {
             "retry" to "もう一度",
             "next_stage" to "次のステージへ",
             "to_stage_map" to "ステージマップ",
-            "star_cond_3" to "⭐⭐⭐  満点 + 平均3秒以内",
+            "star_cond_3" to "⭐⭐⭐  満点 + 平均6秒以内",
             "star_cond_2" to "⭐⭐  8問以上正解",
-            "star_cond_1" to "⭐  全問クリア"
+            "star_cond_1" to "⭐  全問クリア",
+            "points_earned" to "%d P 獲得！",
+            "hearts_display" to "❤️ %d / %d",
+            "next_heart_timer" to "+1 %02d:%02d",
+            "total_points_format" to "累計 %d P"
         )
     )
 
@@ -296,6 +316,7 @@ private fun kmpFormat(template: String, vararg args: Any): String {
         if (template[i] == '%' && i + 1 < template.length) {
             val rest = template.substring(i + 1)
             val floatMatch = Regex("^\\.(\\d+)f").find(rest)
+            val paddedIntMatch = Regex("^0(\\d+)d").find(rest)
             val stringMatch = rest.startsWith("s")
             val intMatch = rest.startsWith("d")
             when {
@@ -304,6 +325,12 @@ private fun kmpFormat(template: String, vararg args: Any): String {
                     val value = (args.getOrNull(argIndex++) as? Number)?.toFloat() ?: 0f
                     result.append(formatFloat(value, decimals))
                     i += 1 + floatMatch.value.length
+                }
+                paddedIntMatch != null -> {
+                    val width = paddedIntMatch.groupValues[1].toInt()
+                    val value = (args.getOrNull(argIndex++) as? Number)?.toInt() ?: 0
+                    result.append(value.toString().padStart(width, '0'))
+                    i += 1 + paddedIntMatch.value.length
                 }
                 stringMatch -> {
                     result.append(args.getOrNull(argIndex++)?.toString() ?: "")

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MainScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MainScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
 
 // ─── Home Screen ──────────────────────────────────────────────────────────────
 
@@ -28,11 +29,14 @@ fun HomeScreen(
     onResumeClick: (Pair<MathOperation, Int>) -> Unit,
     onNewStartClick: () -> Unit,
     onResetProgress: () -> Unit,
-    progressVersion: Int
+    progressVersion: Int,
+    heartsVersion: Int
 ) {
     val lastStage = remember(progressVersion) { getLastPlayedStage() }
     var showResetConfirm by remember { mutableStateOf(false) }
     var showLanguageSheet by remember { mutableStateOf(false) }
+    val hearts = rememberLiveHearts(heartsVersion)
+    val totalPoints = remember(progressVersion) { getTotalPoints() }
 
     LaunchedEffect(Unit) {
         if (appLanguageRaw.isEmpty()) onAppLanguageChange(getDeviceLanguageCode())
@@ -46,6 +50,11 @@ fun HomeScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.SpaceBetween
         ) {
+            // ── Hearts + Points header ──
+            HeartsHeader(hearts = hearts, appLanguage = appLanguage, totalPoints = totalPoints)
+
+            Spacer(modifier = Modifier.height(4.dp))
+
             // ── Top bar ──
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -138,6 +147,7 @@ fun HomeScreen(
                 val (op, num) = lastStage
                 Button(
                     onClick = { onResumeClick(lastStage) },
+                    enabled = hearts > 0,
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(64.dp)
@@ -212,6 +222,75 @@ fun HomeScreen(
                         Text(L10n.string("cancel", appLanguage))
                     }
                 }
+            )
+        }
+    }
+}
+
+@Composable
+fun rememberLiveHearts(refreshKey: Int): Int {
+    var hearts by remember(refreshKey) {
+        mutableIntStateOf(run {
+            rechargeHearts()
+            getHearts()
+        })
+    }
+
+    LaunchedEffect(refreshKey) {
+        while (true) {
+            rechargeHearts()
+            hearts = getHearts()
+            delay(1000)
+        }
+    }
+
+    return hearts
+}
+
+// ─── Hearts Header ────────────────────────────────────────────────────────────
+
+@Composable
+fun HeartsHeader(hearts: Int, appLanguage: AppLanguage, totalPoints: Int? = null) {
+    var secondsLeft by remember { mutableLongStateOf(secondsUntilNextHeart()) }
+
+    LaunchedEffect(hearts) {
+        while (true) {
+            secondsLeft = secondsUntilNextHeart()
+            delay(1000)
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = if (totalPoints != null) Arrangement.SpaceBetween else Arrangement.Center
+    ) {
+        // Hearts + recharge timer
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                L10n.string("hearts_display", appLanguage, hearts, MAX_HEARTS),
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (hearts < MAX_HEARTS) {
+                Spacer(modifier = Modifier.width(6.dp))
+                val m = secondsLeft / 60
+                val s = secondsLeft % 60
+                Text(
+                    L10n.string("next_heart_timer", appLanguage, m, s),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        // Total points (HomeScreen only)
+        if (totalPoints != null && totalPoints > 0) {
+            Text(
+                L10n.string("total_points_format", appLanguage, totalPoints),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
             )
         }
     }

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MathApp.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/MathApp.kt
@@ -24,7 +24,8 @@ sealed class Screen {
         val stageNumber: Int,
         val stars: Int,
         val correctCount: Int,
-        val avgSeconds: Float
+        val avgSeconds: Float,
+        val points: Int
     ) : Screen()
 }
 
@@ -37,6 +38,19 @@ fun MathApp() {
     var screen by remember { mutableStateOf<Screen>(Screen.Home) }
     // Bump this whenever stage progress changes so child screens re-read AppSettings
     var progressVersion by remember { mutableIntStateOf(0) }
+    // Bump this whenever hearts are consumed/recharged so UI refreshes
+    var heartsVersion by remember { mutableIntStateOf(0) }
+
+    fun enterGame(op: MathOperation, num: Int) {
+        rechargeHearts()
+        if (!consumeHeart()) {
+            heartsVersion++
+            return
+        }
+        heartsVersion++
+        saveLastPlayedStage(op, num)
+        screen = Screen.Game(op, num)
+    }
 
     val appLanguage = when {
         appLanguageRaw.isEmpty() -> AppLanguage.fromCode(getDeviceLanguageCode())
@@ -61,16 +75,14 @@ fun MathApp() {
                         appLanguageRaw = it
                         AppSettings.setString("appLanguage", it)
                     },
-                    onResumeClick = { (op, num) ->
-                        saveLastPlayedStage(op, num)
-                        screen = Screen.Game(op, num)
-                    },
+                    onResumeClick = { (op, num) -> enterGame(op, num) },
                     onNewStartClick = { screen = Screen.Category },
                     onResetProgress = {
                         resetAllProgress()
                         progressVersion++
                     },
-                    progressVersion = progressVersion
+                    progressVersion = progressVersion,
+                    heartsVersion = heartsVersion
                 )
 
                 is Screen.Category -> CategoryScreen(
@@ -83,12 +95,10 @@ fun MathApp() {
                 is Screen.StageMap -> StageMapScreen(
                     operation = s.operation,
                     appLanguage = appLanguage,
-                    onStageSelected = { num ->
-                        saveLastPlayedStage(s.operation, num)
-                        screen = Screen.Game(s.operation, num)
-                    },
+                    onStageSelected = { num -> enterGame(s.operation, num) },
                     onBack = { screen = Screen.Category },
-                    progressVersion = progressVersion
+                    progressVersion = progressVersion,
+                    heartsVersion = heartsVersion
                 )
 
                 is Screen.Game -> GameScreen(
@@ -97,8 +107,10 @@ fun MathApp() {
                     appLanguage = appLanguage,
                     onComplete = { stars, correctCount, avgSec ->
                         saveStageResult(s.operation, s.stageNumber, stars)
+                        val points = calcPoints(s.stageNumber, stars)
+                        addPoints(points)
                         progressVersion++
-                        screen = Screen.Result(s.operation, s.stageNumber, stars, correctCount, avgSec)
+                        screen = Screen.Result(s.operation, s.stageNumber, stars, correctCount, avgSec, points)
                     },
                     onBack = { screen = Screen.StageMap(s.operation) }
                 )
@@ -106,17 +118,20 @@ fun MathApp() {
                 is Screen.Result -> {
                     val nextNum = s.stageNumber + 1
                     val hasNextStage = nextNum <= 10 && StageInfo(s.operation, nextNum).isUnlocked
+                    val hearts = rememberLiveHearts(heartsVersion)
                     ResultScreen(
                         operation = s.operation,
                         stageNumber = s.stageNumber,
                         stars = s.stars,
                         correctCount = s.correctCount,
                         avgSeconds = s.avgSeconds,
+                        points = s.points,
+                        hearts = hearts,
                         appLanguage = appLanguage,
                         hasNextStage = hasNextStage,
-                        onRetry = { screen = Screen.Game(s.operation, s.stageNumber) },
+                        onRetry = { enterGame(s.operation, s.stageNumber) },
                         onNextStage = {
-                            if (hasNextStage) screen = Screen.Game(s.operation, nextNum)
+                            if (hasNextStage) enterGame(s.operation, nextNum)
                             else screen = Screen.StageMap(s.operation)
                         },
                         onToStageMap = { screen = Screen.StageMap(s.operation) }

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/PlatformUtils.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/PlatformUtils.kt
@@ -4,6 +4,9 @@ expect fun getDeviceLanguageCode(): String
 
 expect fun currentTimeMillis(): Long
 
+/** Wall-clock seconds since Unix epoch — safe to use across app restarts. */
+expect fun getCurrentEpochSeconds(): Long
+
 expect fun setHardwareKeyboardHandler(
     onDigit: ((String) -> Unit)? = null,
     onBackspace: (() -> Unit)? = null,

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/ResultScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/ResultScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -24,6 +25,8 @@ fun ResultScreen(
     stars: Int,
     correctCount: Int,
     avgSeconds: Float,
+    points: Int,
+    hearts: Int,
     appLanguage: AppLanguage,
     hasNextStage: Boolean,
     onRetry: () -> Unit,
@@ -48,6 +51,8 @@ fun ResultScreen(
                 .padding(horizontal = 24.dp, vertical = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            HeartsHeader(hearts = hearts, appLanguage = appLanguage)
+
             Spacer(modifier = Modifier.weight(1f))
 
             // Stage label
@@ -74,6 +79,11 @@ fun ResultScreen(
 
             Spacer(modifier = Modifier.height(28.dp))
 
+            // Animated points display
+            PointsDisplay(points = points, appLanguage = appLanguage)
+
+            Spacer(modifier = Modifier.height(20.dp))
+
             // Stats card
             Surface(
                 shape = RoundedCornerShape(16.dp),
@@ -97,26 +107,6 @@ fun ResultScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Star condition hints
-            Column(
-                horizontalAlignment = Alignment.Start,
-                modifier = Modifier.fillMaxWidth(0.8f)
-            ) {
-                listOf("star_cond_3", "star_cond_2", "star_cond_1").forEachIndexed { idx, key ->
-                    val condStars = 3 - idx
-                    Text(
-                        L10n.string(key, appLanguage),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (stars >= condStars)
-                            MaterialTheme.colorScheme.primary
-                        else
-                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-                    )
-                }
-            }
-
             Spacer(modifier = Modifier.weight(1f))
 
             // Action buttons
@@ -136,6 +126,7 @@ fun ResultScreen(
                 // "다시 하기" — always visible
                 OutlinedButton(
                     onClick = onRetry,
+                    enabled = hearts > 0,
                     modifier = Modifier.fillMaxWidth().height(52.dp),
                     shape = RoundedCornerShape(14.dp)
                 ) {
@@ -146,6 +137,7 @@ fun ResultScreen(
                 if (hasNextStage) {
                     Button(
                         onClick = onNextStage,
+                        enabled = hearts > 0,
                         modifier = Modifier.fillMaxWidth().height(52.dp),
                         shape = RoundedCornerShape(14.dp)
                     ) {
@@ -210,6 +202,38 @@ private fun StarDisplay(stars: Int) {
                     else MaterialTheme.colorScheme.onSurface.copy(alpha = emptyAlpha)
         )
     }
+}
+
+// ─── Animated points display ──────────────────────────────────────────────────
+
+@Composable
+private fun PointsDisplay(points: Int, appLanguage: AppLanguage) {
+    var displayedPoints by remember { mutableIntStateOf(0) }
+    val scale = remember { Animatable(0.5f) }
+
+    LaunchedEffect(points) {
+        kotlinx.coroutines.delay(600)
+        scale.animateTo(1.15f, animationSpec = tween(300))
+        scale.animateTo(1f, animationSpec = tween(150))
+        // Count-up animation
+        val steps = 20
+        val stepDelay = 500L / steps
+        for (i in 1..steps) {
+            displayedPoints = (points * i / steps)
+            kotlinx.coroutines.delay(stepDelay)
+        }
+        displayedPoints = points
+    }
+
+    Text(
+        L10n.string("points_earned", appLanguage, displayedPoints),
+        style = MaterialTheme.typography.headlineMedium,
+        fontSize = 44.sp,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.scale(scale.value),
+        textAlign = TextAlign.Center
+    )
 }
 
 // ─── Confetti (3-star celebration) ───────────────────────────────────────────

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageData.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageData.kt
@@ -91,6 +91,7 @@ fun resetAllProgress() {
     }
     AppSettings.setString("last_op", "")
     AppSettings.setInt("last_stage_num", 0)
+    AppSettings.setInt("total_points", 0)
 }
 
 // ─── Star calculation ─────────────────────────────────────────────────────────
@@ -100,10 +101,76 @@ fun resetAllProgress() {
 fun calcStars(correctCount: Int, totalSeconds: Float): Int {
     val avg = totalSeconds / 10f
     return when {
-        correctCount == 10 && avg <= 3f -> 3
+        correctCount == 10 && avg <= 6f -> 3
         correctCount >= 8               -> 2
         else                            -> 1
     }
+}
+
+// ─── Point calculation ────────────────────────────────────────────────────────
+
+/** Returns points earned for a stage result.
+ *  stageNumber 1~3 = easy tier, 4~6 = normal tier, 7~10 = hard tier. */
+fun calcPoints(stageNumber: Int, stars: Int): Int {
+    return when {
+        stageNumber <= 3 -> when (stars) { 1 -> 100; 2 -> 110; else -> 120 }
+        stageNumber <= 6 -> when (stars) { 1 -> 150; 2 -> 165; else -> 180 }
+        else             -> when (stars) { 1 -> 200; 2 -> 220; else -> 240 }
+    }
+}
+
+fun addPoints(points: Int) {
+    val current = AppSettings.getInt("total_points", 0)
+    AppSettings.setInt("total_points", current + points)
+}
+
+fun getTotalPoints(): Int = AppSettings.getInt("total_points", 0)
+
+// ─── Heart (Energy) System ────────────────────────────────────────────────────
+
+const val MAX_HEARTS = 15
+const val HEART_RECHARGE_SECONDS = 300L // 5 minutes per heart
+
+/** Must be called on screen entry to credit hearts earned while app was closed. */
+fun rechargeHearts() {
+    val hearts = AppSettings.getInt("hearts", MAX_HEARTS)
+    if (hearts >= MAX_HEARTS) return
+    val currentTime = getCurrentEpochSeconds()
+    val lastChargeTime = AppSettings.getString("last_heart_charge_time", "0").toLongOrNull() ?: currentTime
+    val elapsed = currentTime - lastChargeTime
+    val toAdd = (elapsed / HEART_RECHARGE_SECONDS).toInt()
+    if (toAdd > 0) {
+        val newHearts = minOf(MAX_HEARTS, hearts + toAdd)
+        AppSettings.setInt("hearts", newHearts)
+        if (newHearts < MAX_HEARTS) {
+            val newLastChargeTime = lastChargeTime + toAdd * HEART_RECHARGE_SECONDS
+            AppSettings.setString("last_heart_charge_time", newLastChargeTime.toString())
+        }
+    }
+}
+
+fun getHearts(): Int = AppSettings.getInt("hearts", MAX_HEARTS)
+
+/** Removes one heart. Returns false if no hearts available. */
+fun consumeHeart(): Boolean {
+    val hearts = getHearts()
+    if (hearts <= 0) return false
+    AppSettings.setInt("hearts", hearts - 1)
+    if (hearts == MAX_HEARTS) {
+        // Was full — start recharge timer now
+        AppSettings.setString("last_heart_charge_time", getCurrentEpochSeconds().toString())
+    }
+    return true
+}
+
+/** Returns seconds remaining until the next heart recharges (0 if full). */
+fun secondsUntilNextHeart(): Long {
+    if (getHearts() >= MAX_HEARTS) return 0L
+    val lastChargeTime = AppSettings.getString("last_heart_charge_time", "0").toLongOrNull()
+        ?: return HEART_RECHARGE_SECONDS
+    val elapsed = getCurrentEpochSeconds() - lastChargeTime
+    val secondsInCurrentCycle = elapsed % HEART_RECHARGE_SECONDS
+    return HEART_RECHARGE_SECONDS - secondsInCurrentCycle
 }
 
 // ─── Aggregate progress ───────────────────────────────────────────────────────

--- a/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageMapScreen.kt
+++ b/android/shared/src/commonMain/kotlin/com/mathapp/practice/ui/StageMapScreen.kt
@@ -25,14 +25,19 @@ fun StageMapScreen(
     appLanguage: AppLanguage,
     onStageSelected: (Int) -> Unit,
     onBack: () -> Unit,
-    progressVersion: Int
+    progressVersion: Int,
+    heartsVersion: Int
 ) {
     val stages = remember(progressVersion) { stagesFor(operation) }
     // "Current" stage = first unlocked stage with 0 stars, else last stage
     val currentIdx = stages.indexOfFirst { it.isUnlocked && it.stars == 0 }
         .let { if (it == -1) stages.size - 1 else it }
+    val hearts = rememberLiveHearts(heartsVersion)
 
     Column(modifier = Modifier.fillMaxSize()) {
+        // ── Hearts header ──
+        HeartsHeader(hearts = hearts, appLanguage = appLanguage)
+
         // ── Top bar ──
         Row(
             modifier = Modifier
@@ -74,7 +79,7 @@ fun StageMapScreen(
                     stageNumber = idx + 1,
                     isCurrent = isCurrent,
                     appLanguage = appLanguage,
-                    onClick = if (isLocked) null else ({ onStageSelected(stage.number) })
+                    onClick = if (isLocked || hearts <= 0) null else ({ onStageSelected(stage.number) })
                 )
             }
             Spacer(modifier = Modifier.height(32.dp))

--- a/android/shared/src/iosMain/kotlin/com/mathapp/practice/ui/PlatformUtils.ios.kt
+++ b/android/shared/src/iosMain/kotlin/com/mathapp/practice/ui/PlatformUtils.ios.kt
@@ -3,6 +3,7 @@ package com.mathapp.practice.ui
 import platform.Foundation.NSUserDefaults
 import platform.Foundation.NSNotification
 import platform.Foundation.NSNotificationCenter
+import platform.posix.time
 import kotlin.time.TimeSource
 
 private val originMark = TimeSource.Monotonic.markNow()
@@ -31,6 +32,9 @@ actual fun getDeviceLanguageCode(): String {
 }
 
 actual fun currentTimeMillis(): Long = originMark.elapsedNow().inWholeMilliseconds
+
+@OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+actual fun getCurrentEpochSeconds(): Long = time(null).toLong()
 
 actual fun setHardwareKeyboardHandler(
     onDigit: ((String) -> Unit)?,


### PR DESCRIPTION
## 요약
- 스테이지 클리어 시 별점과 난이도 구간에 따라 포인트를 지급하는 보상 시스템을 추가했습니다.
- 플레이 세션 길이를 제어하기 위해 최대 15개, 5분당 1개 회복 규칙의 하트 에너지 시스템을 도입했습니다.
- 3-star 조건을 평균 3초 이하에서 평균 6초 이하로 완화하고, 결과/홈/스테이지 맵 화면에 관련 UX를 확장했습니다.

## 상세 변경 사항
- `StageData`에 포인트 계산, 누적 포인트 저장, 하트 저장/소모/자동 회복 로직을 추가했습니다.
- 공통 플랫폼 계층에 Unix epoch 초 단위 시간을 추가하고 Android/iOS actual 구현을 연결해 앱 재시작 이후에도 하트 충전 시간이 이어지도록 했습니다.
- 홈 화면 상단에 하트 수량, 다음 하트 충전 타이머, 누적 포인트를 표시하는 헤더를 추가했습니다.
- 스테이지 맵에서도 하트 상태를 표시하고, 하트가 없으면 스테이지 진입이 비활성화되도록 조정했습니다.
- 결과 화면에 획득 포인트 애니메이션을 추가하고, 하트가 없을 경우 재시도/다음 단계 버튼이 비활성화되도록 변경했습니다.
- 게임 진입 공통 경로를 정리해 하트 소모 실패 시 실제 게임 화면으로 진입하지 않도록 가드했습니다.
- 하트가 자동 충전되는 동안 화면에 머물러도 버튼 상태와 헤더 표시가 함께 갱신되도록 라이브 상태 동기화를 보강했습니다.
- 모든 지원 언어에 포인트/하트/타이머/누적 포인트 문구를 추가했고, 공통 포매터가 0-padding 정수 포맷을 처리할 수 있도록 확장했습니다.

## 밸런스 변경
- 3-star 획득 조건: `만점 + 평균 6초 이하`로 완화
- 포인트 지급 규칙:
  - 1~3단계: 1별 100P / 2별 110P / 3별 120P
  - 4~6단계: 1별 150P / 2별 165P / 3별 180P
  - 7~10단계: 1별 200P / 2별 220P / 3별 240P
- 하트 규칙: 최대 15개, 5분마다 1개 자동 회복

## 테스트
- `./gradlew clean :app:assembleDebug`

## 리뷰 포인트
- 포인트 보상량과 3-star 조건 완화가 실제 체감 난이도와 잘 맞는지
- 하트 소모/회복 타이밍이 플레이 흐름을 과도하게 끊지 않는지
- 홈, 스테이지 맵, 결과 화면에서 하트 상태가 사용자에게 충분히 명확하게 전달되는지
- 반복 플레이 시 포인트 누적 방식이 기획 의도와 일치하는지